### PR TITLE
修复了试图在Pydantic模型对象上使用字典的.get()方法的问题

### DIFF
--- a/ui/pyqt_chat_window.py
+++ b/ui/pyqt_chat_window.py
@@ -5,7 +5,7 @@ from PyQt5.QtCore import Qt, QRect, QParallelAnimationGroup, QPropertyAnimation,
 from PyQt5.QtGui import QColor, QPainter, QBrush, QFont, QPen
 from conversation_core import NagaConversation
 import os
-from config import config, AI_NAME # 导入统一配置
+from config import config, AI_NAME, Live2DConfig # 导入统一配置
 from ui.response_utils import extract_message  # 新增：引入消息提取工具
 from ui.styles.progress_widget import EnhancedProgressWidget  # 导入进度组件
 from ui.enhanced_worker import StreamingWorker, BatchWorker  # 导入增强Worker
@@ -302,8 +302,8 @@ class ChatWindow(QWidget):
         s._img_inited = False  # 标志变量，图片自适应只在初始化时触发一次
         
         # Live2D相关配置
-        s.live2d_enabled = getattr(config, 'live2d', {}).get('enabled', False)  # 是否启用Live2D
-        s.live2d_model_path = getattr(config, 'live2d', {}).get('model_path', '')  # Live2D模型路径
+        s.live2d_enabled = getattr(config, 'live2d', Live2DConfig()).enabled  # 是否启用Live2D
+        s.live2d_model_path = getattr(config, 'live2d', Live2DConfig()).model_path  # Live2D模型路径
         
         # 初始化消息存储
         s._messages = {}


### PR DESCRIPTION
已成功修复Live2D配置错误。问题在于代码试图在Pydantic模型对象上使用字典的.get()方法。现在直接访问模型的属性即可。