### PR TITLE
Fix: Spelling mistake line503 List->list

### DIFF
--- a/ui/message_renderer.py
+++ b/ui/message_renderer.py
@@ -500,7 +500,7 @@ class MessageRenderer:
         return dialogs
     
     @staticmethod
-    def load_persistent_context_to_ui(parent_widget, max_messages: int = None) -> List[tuple]:
+    def load_persistent_context_to_ui(parent_widget, max_messages: int = None) -> list[tuple]:
         """
         将持久化上下文加载到前端UI
         


### PR DESCRIPTION
使用start_with_tray.bat中引起启动失败，已修复