### PR TITLE
[Patch] Comic Service Fix

### DIFF
--- a/mcpserver/agent_comic_downloader/comic_service.py
+++ b/mcpserver/agent_comic_downloader/comic_service.py
@@ -117,6 +117,7 @@ class ComicService:
                         "data": ""
                     }, ensure_ascii=False)
             result = await func(data.get('param_name'))
+            self.logger.debug(f"操作结果: {result}")
             if result:
                 return json.dumps({
                     "status": "success",
@@ -128,16 +129,12 @@ class ComicService:
                 "message": f"操作失败: {tool_name}",
                 "data": ""
             }, ensure_ascii=False)
-        except:
-            return json.dumps({
-                "status": "error",
-                "message": "未知错误",
-                "data": ""
-            }, ensure_ascii=False)
+        except Exception as e:
+            self.logger.error(f"操作失败: {e}")
     
     # ==================== 下载功能 ====================
     
-    def download_comic(self, album_id: str) -> Dict[str, Any]:
+    async def download_comic(self, album_id: str) -> Dict[str, Any]:
         """
         下载漫画
         
@@ -195,7 +192,7 @@ class ComicService:
     
     # ==================== 搜索功能 ====================
     
-    def search_comic_by_name(self, comic_name: str, page: int = 1) -> Dict[str, Any]:
+    async def search_comic_by_name(self, comic_name: str, page: int = 1) -> Dict[str, Any]:
         """
         按漫画名搜索
         
@@ -231,7 +228,7 @@ class ComicService:
                 'type': 'comic_name'
             }
     
-    def search_comic_by_author(self, author_name: str, page: int = 1) -> Dict[str, Any]:
+    async def search_comic_by_author(self, author_name: str, page: int = 1) -> Dict[str, Any]:
         """
         按作者名搜索
         
@@ -267,7 +264,7 @@ class ComicService:
                 'type': 'author'
             }
     
-    def get_comic_detail(self, comic_id: str) -> Dict[str, Any]:
+    async def get_comic_detail(self, comic_id: str) -> Dict[str, Any]:
         """
         获取漫画详情
         
@@ -308,7 +305,7 @@ class ComicService:
                 'comic_id': comic_id
             }
     
-    def _format_search_result(self, search_page: JmSearchPage, query_info: str) -> Dict[str, Any]:
+    async def _format_search_result(self, search_page: JmSearchPage, query_info: str) -> Dict[str, Any]:
         """
         格式化搜索结果
         


### PR DESCRIPTION
修复了ComicService的格式错误（没有handle_handoff函数）。
仍然存在问题：模型往往会调用错误的参数名。可能是因为读入agent-manifest.json的get_agent_metadata从来没有被调用过？这应该是另外一个bug，但是不在本补丁的修复范围之内了。
回头我可以查查。