### PR TITLE
将 agentserver 工具包集成到意图推测系统（修复 #155 问题2）

### DIFF
--- a/system/prompts/conversation_analyzer_prompt.txt
+++ b/system/prompts/conversation_analyzer_prompt.txt
@@ -3,10 +3,18 @@
 ## 输出格式要求
 你必须严格按照以下非标准JSON格式输出：
 
-**MCP工具调用**：
+**MCP工具调用**（标记为 [MCP] 的工具）：
 ｛
 "agentType": "mcp",
 "service_name": "MCP服务名称",
+"tool_name": "工具名称",
+"param_name": "参数值"
+｝
+
+**Agent工具包调用**（标记为 [Agent] 的工具包）：
+｛
+"agentType": "agent",
+"service_name": "工具包名称",
 "tool_name": "工具名称",
 "param_name": "参数值"
 ｝
@@ -48,15 +56,26 @@
 "url": "https://www.bilibili.com"
 ｝
 
+输入对话："帮我编辑文件 test.txt"
+期望输出：
+｛
+"agentType": "agent",
+"service_name": "file_edit",
+"tool_name": "edit_file",
+"file_path": "test.txt",
+"content": "要编辑的内容"
+｝
+
 【输入对话】
 {conversation}
 
-【可用MCP工具】
+【可用工具】
 {available_tools}
 
 ## 重要要求
 - 仅提取可以交给工具执行的任务，忽略闲聊
 - 工具参数必须完整、具体
-- 如果用户请求涉及工具调用（如查询天气、搜索信息、处理文件等），必须识别并返回相应的工具调用
+- 根据工具标记选择正确的 agentType：[MCP] 工具使用 "mcp"，[Agent] 工具包使用 "agent"
+- 如果用户请求涉及工具调用（如查询天气、搜索信息、处理文件、编辑文件等），必须识别并返回相应的工具调用
 - 如果没有发现可执行任务，输出：｛｝
 - 如果有什么要记住的，必须调用记忆工具进行记忆


### PR DESCRIPTION
修复 #155  提出的问题2。

- 修改 background_analyzer.py，同时获取 MCP 服务和 agentserver 工具包信息
- 更新意图识别提示词，支持 [MCP] 和 [Agent] 标记的工具
- 修改 agent_server.py，支持工具包调用和电脑控制任务两种类型
- 添加 _process_toolkit_call 函数处理工具包调用