### PR TITLE
fix: 修复OpenClaw回调在前端不显示的问题

### DIFF
--- a/frontend/src/views/MessageView.vue
+++ b/frontend/src/views/MessageView.vue
@@ -43,14 +43,12 @@ export function chatStream(content: string) {
     if (!message.reasoning) {
       delete message.reasoning
     }
-    stopToolPolling()
 
     if (CONFIG.value.system.voice_enabled && message.content) {
       speak(message.content)
     }
   }).catch((err) => {
     MESSAGES.value.push({ role: 'system', content: `Error: ${err.message}` })
-    stopToolPolling()
   })
 }
 </script>
@@ -161,6 +159,7 @@ async function handleFileUpload(event: Event) {
 
 onMounted(() => {
   loadCurrentSession()
+  startToolPolling()
   scrollToBottom()
 })
 onUnmounted(() => {


### PR DESCRIPTION
## Summary
- 在页面 `onMounted` 时启动工具状态轮询，确保后台任务消息能被接收
- 移除 `chatStream` 完成后的 `stopToolPolling()` 调用，因为 OpenClaw 任务可能在主对话完成后仍在执行
- 轮询只在页面 `onUnmounted` 时停止

## 问题原因
1. 之前 `startToolPolling()` 只在用户发送消息时（`chatStream` 函数）才启动，但 OpenClaw 回复是后台产生的，不依赖于用户发送消息
2. `chatStream` 完成后立即调用 `stopToolPolling()`，导致轮询停止时 OpenClaw 任务可能还在执行，无法获取后续回复