### PR TITLE
fix: OpenClaw 2026.2.17 sessionKey compatibility and global-install preference

### DIFF
--- a/agentserver/agent_server.py
+++ b/agentserver/agent_server.py
@@ -138,7 +138,11 @@ async def lifespan(app: FastAPI):
         # 初始化 OpenClaw 客户端 - 三层回退策略
         try:
             from agentserver.openclaw import detect_openclaw, OpenClawConfig as ClientOpenClawConfig
-            from agentserver.openclaw.llm_config_bridge import ensure_openclaw_config, inject_naga_llm_config
+            from agentserver.openclaw.llm_config_bridge import (
+                ensure_openclaw_config,
+                inject_naga_llm_config,
+                ensure_hooks_allow_request_session_key,
+            )
 
             embedded_runtime = get_embedded_runtime()
             mode = embedded_runtime.runtime_mode
@@ -147,28 +151,31 @@ async def lifespan(app: FastAPI):
             has_embedded_openclaw: bool = False
 
             if embedded_runtime.is_packaged:
-                logger.info("打包环境：准备启动内嵌 OpenClaw Gateway")
-
-                # 首次运行时自动执行 onboard 初始化（含 fallback 配置生成）
-                onboard_ok = await embedded_runtime.ensure_onboarded()
-                if not onboard_ok:
-                    logger.error("OpenClaw 初始化失败（onboard + fallback 均失败）")
-
-                # 检测端口是否已被占用
-                if _is_port_in_use(18789):
-                    logger.info("端口 18789 已被占用，跳过内嵌 Gateway 启动")
-                else:
-                    gw_ok = await embedded_runtime.start_gateway()
-                    if gw_ok:
-                        logger.info("内嵌 OpenClaw Gateway 启动成功")
-                    else:
-                        logger.error("内嵌 OpenClaw Gateway 启动失败")
-
-            # === 打包环境 ===
-            if embedded_runtime.is_packaged:
                 has_global_openclaw = shutil.which("openclaw") is not None
                 has_embedded_openclaw = embedded_runtime.openclaw_installed
 
+                if has_global_openclaw:
+                    logger.info("打包环境：检测到全局安装 OpenClaw，跳过内嵌 OpenClaw 初始化/启动")
+                else:
+                    logger.info("打包环境：准备启动内嵌 OpenClaw Gateway")
+
+                    # 首次运行时自动执行 onboard 初始化（含 fallback 配置生成）
+                    onboard_ok = await embedded_runtime.ensure_onboarded()
+                    if not onboard_ok:
+                        logger.error("OpenClaw 初始化失败（onboard + fallback 均失败）")
+
+                    # 检测端口是否已被占用
+                    if _is_port_in_use(18789):
+                        logger.info("端口 18789 已被占用，跳过内嵌 Gateway 启动")
+                    else:
+                        gw_ok = await embedded_runtime.start_gateway()
+                        if gw_ok:
+                            logger.info("内嵌 OpenClaw Gateway 启动成功")
+                        else:
+                            logger.error("内嵌 OpenClaw Gateway 启动失败")
+
+            # === 打包环境 ===
+            if embedded_runtime.is_packaged:
                 if has_global_openclaw:
                     logger.info("打包环境：检测到全局安装的 OpenClaw，优先使用")
                     # 记录使用系统已有，避免卸载时误清理用户目录
@@ -197,6 +204,8 @@ async def lifespan(app: FastAPI):
             # === 统一：按运行时来源处理配置与 Gateway ===
             openclaw_available = has_global_openclaw or has_embedded_openclaw
             if openclaw_available:
+                # 兼容 OpenClaw 2026.2.17+：确保 hooks 允许外部 sessionKey（必须在 Gateway 启动前/初始化前补齐）
+                ensure_hooks_allow_request_session_key(auto_create=False)
                 use_embedded_openclaw = _should_use_embedded_openclaw(embedded_runtime)
 
                 # 仅在内嵌 OpenClaw 场景下自动写 ~/.openclaw 配置并注入 Naga LLM 配置

--- a/agentserver/openclaw/config_manager.py
+++ b/agentserver/openclaw/config_manager.py
@@ -59,6 +59,7 @@ class OpenClawConfigManager:
         # Hooks 配置
         "hooks.enabled",
         "hooks.token",
+        "hooks.allowRequestSessionKey",
 
         # Skills 配置
         "skills.entries",
@@ -297,6 +298,10 @@ class OpenClawConfigManager:
         """设置 Hooks token"""
         return self.set("hooks.token", token)
 
+    def set_hooks_allow_request_session_key(self, enabled: bool) -> ConfigUpdateResult:
+        """允许/禁止外部 hooks 请求传入 sessionKey"""
+        return self.set("hooks.allowRequestSessionKey", enabled)
+
     def generate_hooks_token(self) -> str:
         """生成随机 Hooks token"""
         return secrets.token_hex(24)
@@ -363,6 +368,7 @@ class OpenClawConfigManager:
         updates = {
             "hooks.enabled": True,
             "hooks.token": hooks_token,
+            "hooks.allowRequestSessionKey": True,
             # 搜索集成：设置 BRAVE_API_KEY 占位值，走本地代理
             "env.BRAVE_API_KEY": "naga-proxy",
         }


### PR DESCRIPTION
## Summary
- fix OpenClaw `/hooks/agent` 400 for external `sessionKey` by ensuring `hooks.allowRequestSessionKey=true`
- add startup-time compatibility patch for existing `~/.openclaw/openclaw.json`
- stop meaningless retries on the specific sessionKey-disabled error and surface actionable message
- prefer system/global OpenClaw in packaged runtime (do not re-init or restart embedded when global exists)
- pin OpenClaw install/preinstall version to `2026.2.17` for stable packaging behavior

## Files
- agentserver/agent_server.py
- agentserver/openclaw/llm_config_bridge.py
- agentserver/openclaw/openclaw_client.py
- agentserver/openclaw/embedded_runtime.py
- agentserver/openclaw/installer.py
- agentserver/openclaw/config_manager.py
- scripts/build-win.py

## Validation
- python -m py_compile on modified Python files passed
