### PR TITLE
fix(market): 为 agent-browser 安装流程添加日志输出

### DIFF
--- a/apiserver/api_server.py
+++ b/apiserver/api_server.py
@@ -333,14 +333,17 @@ def _update_mcporter_firecrawl_config(api_key: Optional[str]) -> Path:
 def _install_agent_browser() -> None:
     if shutil.which("npm") is None:
         raise RuntimeError("未找到 npm，无法安装 agent-browser")
+    logger.info("正在 npm install -g agent-browser ...")
     code, stdout, stderr = _run_command(["npm", "install", "-g", "agent-browser", "--force"], timeout=3000)
     if code != 0:
         raise RuntimeError(stderr or stdout or "npm install -g agent-browser --force 失败")
     if shutil.which("agent-browser") is None:
         raise RuntimeError("agent-browser 未安装成功或未在 PATH 中")
+    logger.info("正在 agent-browser install（下载浏览器，可能需要数分钟）...")
     code, stdout, stderr = _run_command(["agent-browser", "install"], timeout=3000)
     if code != 0:
         raise RuntimeError(stderr or stdout or "agent-browser install 失败")
+    logger.info("agent-browser 安装完成")
 
 
 def _build_market_item(item: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## 问题

agent-browser 安装过程中无任何日志输出，用户点击安装按钮后日志文件无变化，无法判断安装是否在进行中。

## 修复

在 `_install_agent_browser()` 中添加三处 INFO 日志：
- npm install 开始
- agent-browser install 开始（提示可能需要数分钟）
- 安装完成