### PR TITLE
修复积分轮询 + 修复音乐播放器 + 修复充值卡片

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -24,6 +24,7 @@ import { useElectron } from '@/composables/useElectron'
 import { useMusicPlayer } from '@/composables/useMusicPlayer'
 import { useParallax } from '@/composables/useParallax'
 import { useStartupProgress } from '@/composables/useStartupProgress'
+import { startToolPolling, stopToolPolling } from '@/composables/useToolStatus'
 import { checkForUpdate, showUpdateDialog, updateInfo } from '@/composables/useVersionCheck'
 import { backendConnected, CONFIG } from '@/utils/config'
 import { clearExpression, setExpression } from '@/utils/live2dController'
@@ -238,6 +239,22 @@ watch(sessionRestored, (restored) => {
   }
 })
 
+// ─── 全局轮询：登录后启动，登出后停止（积分刷新 + 心跳检测）───
+watch(isNagaLoggedIn, (loggedIn) => {
+  if (loggedIn && backendConnected.value) {
+    startToolPolling()
+  }
+  else {
+    stopToolPolling()
+  }
+}, { immediate: true })
+
+watch(backendConnected, (connected) => {
+  if (connected && isNagaLoggedIn.value) {
+    startToolPolling()
+  }
+})
+
 onMounted(() => {
   initParallax()
   startProgress()
@@ -295,6 +312,7 @@ onMounted(() => {
 onUnmounted(() => {
   destroyParallax()
   cleanup()
+  stopToolPolling()
   unsubStateChange?.()
 })
 </script>

--- a/frontend/src/composables/useMusicPlayer.ts
+++ b/frontend/src/composables/useMusicPlayer.ts
@@ -97,7 +97,8 @@ function setupAudioForTrack() {
   if (!audio || !currentTrack.value)
     return
   // 如果已经在播放同一首曲目，不重置进度（避免切换到音律坊时进度归零）
-  if (audio.src && audio.src.endsWith(currentTrack.value.src))
+  // 注意：浏览器会将 audio.src 中的中文做 URL 编码，需要 decode 后再比较
+  if (audio.src && decodeURIComponent(audio.src).endsWith(currentTrack.value.src))
     return
   audio.src = currentTrack.value.src
   audio.currentTime = 0

--- a/frontend/src/composables/useToolStatus.ts
+++ b/frontend/src/composables/useToolStatus.ts
@@ -1,5 +1,6 @@
 import { ref } from 'vue'
 import API from '@/api/core'
+import { authExpired } from '@/api'
 import { triggerAction } from '@/utils/live2dController'
 import { MESSAGES } from '@/utils/session'
 import { handleMusicCommand } from '@/composables/useMusicPlayer'
@@ -8,6 +9,7 @@ import { isNagaLoggedIn, refreshUserStats } from '@/composables/useAuth'
 export const toolMessage = ref('')
 export const openclawTasks = ref<Array<Record<string, any>>>([])
 let timer: ReturnType<typeof setInterval> | null = null
+let consecutiveFailures = 0
 
 async function poll() {
   try {
@@ -18,6 +20,9 @@ async function poll() {
       API.getLive2dActions(),
       API.getMusicCommands(),
     ])
+
+    // 轮询成功，重置失败计数
+    consecutiveFailures = 0
 
     // 轮询时刷新积分
     if (isNagaLoggedIn.value) {
@@ -59,7 +64,12 @@ async function poll() {
     }
   }
   catch {
-    // ignore polling errors
+    consecutiveFailures++
+    // 连续 3 次轮询失败且已登录 → 触发重新登录弹窗
+    if (consecutiveFailures >= 3 && isNagaLoggedIn.value) {
+      authExpired.value = true
+      consecutiveFailures = 0 // 重置，避免反复触发
+    }
   }
 }
 

--- a/frontend/src/views/FloatingView.vue
+++ b/frontend/src/views/FloatingView.vue
@@ -5,7 +5,7 @@ import ScrollPanel from 'primevue/scrollpanel'
 import { computed, nextTick, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
 import API from '@/api/core'
 import MessageItem from '@/components/MessageItem.vue'
-import { startToolPolling, stopToolPolling, toolMessage } from '@/composables/useToolStatus'
+import { toolMessage } from '@/composables/useToolStatus'
 import { CONFIG } from '@/utils/config'
 import { CURRENT_SESSION_ID, formatRelativeTime, IS_TEMPORARY_SESSION, loadCurrentSession, MESSAGES, newSession, newTemporarySession, switchSession } from '@/utils/session'
 import { chatStream } from '@/views/MessageView.vue'
@@ -178,9 +178,8 @@ onMounted(() => {
   // 启动序列帧动画
   startFrameAnimation()
 
-  // 加载会话和工具状态
+  // 加载会话
   loadCurrentSession()
-  startToolPolling()
 
   // 获取初始状态
   api.floating.getState().then((state) => {
@@ -234,7 +233,6 @@ onUnmounted(() => {
   document.documentElement.style.backgroundColor = '#110901'
   unsubStateChange?.()
   unsubBlur?.()
-  stopToolPolling()
   stopFrameAnimation()
   stopNotification()
   resizeObserver?.disconnect()

--- a/frontend/src/views/MarketView.vue
+++ b/frontend/src/views/MarketView.vue
@@ -670,7 +670,6 @@ async function handleRedeem() {
           >
             <div class="card-credits">{{ product.credits }}</div>
             <div class="card-unit">积分</div>
-            <div class="card-name">{{ product.name }}</div>
             <div class="card-price">{{ product.price }}</div>
           </div>
         </div>
@@ -1757,7 +1756,6 @@ async function handleRedeem() {
 }
 .recharge-card .card-credits { font-size: 1.8rem; font-weight: bold; color: #d4af37; }
 .recharge-card .card-unit { font-size: 0.7rem; color: rgba(255,255,255,0.4); margin-top: -0.2rem; }
-.recharge-card .card-name { font-size: 0.85rem; color: rgba(255,255,255,0.8); margin-top: 0.3rem; }
 .recharge-card .card-price { font-size: 1rem; font-weight: 600; color: rgba(255,255,255,0.9); margin-top: 0.2rem; }
 
 .recharge-redeem { display: flex; gap: 0.5rem; max-width: 360px; margin: 0 auto; }

--- a/frontend/src/views/MessageView.vue
+++ b/frontend/src/views/MessageView.vue
@@ -1,11 +1,11 @@
 <script lang="ts">
 import { onKeyStroke, useEventListener } from '@vueuse/core'
-import { nextTick, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
+import { nextTick, onMounted, ref, useTemplateRef, watch } from 'vue'
 import { ACCESS_TOKEN, authExpired } from '@/api'
 import API from '@/api/core'
 import BoxContainer from '@/components/BoxContainer.vue'
 import MessageItem from '@/components/MessageItem.vue'
-import { startToolPolling, stopToolPolling, toolMessage } from '@/composables/useToolStatus'
+import { toolMessage } from '@/composables/useToolStatus'
 import { CONFIG } from '@/utils/config'
 import { live2dState, setEmotion } from '@/utils/live2dController'
 import { CURRENT_SESSION_ID, formatRelativeTime, IS_TEMPORARY_SESSION, loadCurrentSession, MESSAGES, newSession, switchSession } from '@/utils/session'
@@ -268,11 +268,7 @@ function sendMessage() {
 
 onMounted(() => {
   loadCurrentSession()
-  startToolPolling()
   scrollToBottom()
-})
-onUnmounted(() => {
-  stopToolPolling()
 })
 useEventListener('token', scrollToBottom)
 onKeyStroke('Enter', (e) => {


### PR DESCRIPTION
- 积分轮询提升到 App.vue 全局管理，登录即启动，不再依赖进入聊天页
- 修复音乐播放器 URL 编码导致同曲目判断失败、每次进入音律坊进度归零
- 移除充值卡片冗余 card-name（还原 rtgs 0d37646 修复）
- 轮询连续 3 次失败触发"账号验证失效"重新登录弹窗