### PR TITLE
ci: add GitHub Actions build & release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,132 @@
+name: Build & Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: '版本号 (如 5.1.0，不带v前缀)'
+        required: false
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            platform: win
+            dist_cmd: dist:win
+            artifact_glob: '*.exe'
+          - os: macos-14
+            platform: mac
+            dist_cmd: dist:mac
+            artifact_glob: '*.dmg'
+          - os: ubuntu-latest
+            platform: linux
+            dist_cmd: dist:linux
+            artifact_glob: '*.AppImage'
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: 'latest'
+
+      # ---------- Backend: PyInstaller ----------
+      - name: Install Python dependencies
+        run: uv pip install --system -r <(uv pip compile pyproject.toml --no-header) pyinstaller
+
+      - name: Compile backend with PyInstaller
+        run: pyinstaller naga-backend.spec --noconfirm
+
+      - name: Prepare backend-dist
+        shell: bash
+        run: |
+          mkdir -p frontend/backend-dist
+          cp -r dist/naga-backend frontend/backend-dist/
+
+      # ---------- OpenClaw runtime (Windows only) ----------
+      - name: Setup OpenClaw runtime
+        if: matrix.platform == 'win'
+        shell: bash
+        run: |
+          mkdir -p frontend/backend-dist/openclaw-runtime
+          # Download portable Node.js for OpenClaw
+          curl -L -o node.zip "https://nodejs.org/dist/v22.14.0/node-v22.14.0-win-x64.zip"
+          unzip -q node.zip -d _node_tmp
+          mv _node_tmp/node-v22.14.0-win-x64 frontend/backend-dist/openclaw-runtime/node
+          # Install OpenClaw globally in portable node
+          frontend/backend-dist/openclaw-runtime/node/npm.cmd install -g @anthropic-ai/claude-code
+
+      # ---------- Frontend: electron-builder ----------
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build & package
+        working-directory: frontend
+        run: npm run ${{ matrix.dist_cmd }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: NagaAgent-${{ matrix.platform }}
+          path: frontend/release/${{ matrix.artifact_glob }}
+          if-no-files-found: error
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine version
+        id: ver
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.version }}" ]; then
+            echo "version=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            echo "tag=v${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            TAG="${GITHUB_REF#refs/tags/}"
+            echo "version=${TAG#v}" >> $GITHUB_OUTPUT
+            echo "tag=$TAG" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.ver.outputs.tag }}
+          name: NagaAgent ${{ steps.ver.outputs.version }}
+          draft: false
+          prerelease: false
+          files: artifacts/**/*
+          generate_release_notes: true


### PR DESCRIPTION
Supports manual trigger (workflow_dispatch) and tag-based trigger (v*). Builds Windows exe, macOS dmg, Linux AppImage via electron-builder.