### PR TITLE
fix: collect charset_normalizer mypyc modules for PyInstaller

### DIFF
--- a/naga-backend.spec
+++ b/naga-backend.spec
@@ -167,10 +167,12 @@ hiddenimports = excludes + [
     'tiktoken_ext.openai_public',
 ]
 hiddenimports += collect_submodules('psutil')
+hiddenimports += collect_submodules('charset_normalizer')
 
 
 
 binaries = collect_dynamic_libs('psutil')
+binaries += collect_dynamic_libs('charset_normalizer')
 
 a = Analysis(
     ['main.py'],


### PR DESCRIPTION
charset_normalizer 3.x uses mypyc compilation producing hash-named .pyd/.so files that PyInstaller static analysis cannot detect, causing ModuleNotFoundError at runtime.