### PR TITLE
fix: move declare global out of script setup (TS1234)

### DIFF
--- a/frontend/src/components/Live2dModel.vue
+++ b/frontend/src/components/Live2dModel.vue
@@ -1,5 +1,13 @@
 <script lang="ts">
 import * as PIXI from 'pixi.js'
+
+declare global {
+  interface Window {
+    PIXI: typeof PIXI
+  }
+}
+
+window.PIXI = PIXI
 </script>
 
 <script setup lang="ts">
@@ -7,12 +15,6 @@ import { Live2DModel } from 'pixi-live2d-display/cubism4'
 import { computed, nextTick, onMounted, onUnmounted, ref, useTemplateRef, watch } from 'vue'
 import { CONFIG } from '@/utils/config'
 import { destroyController, initController, startTracking, stopTracking, trackingCalibration, updateTracking } from '@/utils/live2dController'
-
-declare global {
-  interface Window {
-    PIXI: typeof PIXI
-  }
-}
 
 const { source, width, height, x, y, scale, ssaa } = defineProps<{
   source: string
@@ -27,8 +29,6 @@ const { source, width, height, x, y, scale, ssaa } = defineProps<{
 const emit = defineEmits<{
   modelReady: [pos: { faceX: number, faceY: number }]
 }>()
-
-window.PIXI = PIXI
 
 let app: PIXI.Application
 


### PR DESCRIPTION
vue-tsc treats script setup as module scope where ambient module declarations are not allowed. Move declare global + window.PIXI assignment to the plain <script> block.