### PR TITLE
 Fix: py2neo Graph() timeout 参数不兼容 & Neo4j 连接状态误报

### DIFF
--- a/main.py
+++ b/main.py
@@ -728,9 +728,9 @@ def _lazy_init_services():
             print(f"GRAG状态: {'启用' if memory_manager.enabled else '禁用'}")
             if memory_manager.enabled:
                 stats = memory_manager.get_memory_stats()
-                from summer_memory.quintuple_graph import get_graph, GRAG_ENABLED
-                graph = get_graph()
-                print(f"Neo4j连接: {'成功' if graph and GRAG_ENABLED else '失败'}")
+                from summer_memory import quintuple_graph as _qg
+                graph = _qg.get_graph()
+                print(f"Neo4j连接: {'成功' if graph and _qg.GRAG_ENABLED else '失败'}")
         print("=" * 30)
         print(f'{AI_NAME}系统已启动')
         print("=" * 30)

--- a/summer_memory/graph.py
+++ b/summer_memory/graph.py
@@ -37,7 +37,7 @@ class Graph:
     def __init__(self, uri: str, user: str, password: str, database: str = "neo4j"):
         if Py2NeoGraph is None:
             raise RuntimeError("py2neo 未安装，请运行 pip install py2neo 或禁用图数据库功能")
-        self.driver = Py2NeoGraph(uri, auth=(user, password), name=database, timeout=5)
+        self.driver = Py2NeoGraph(uri, auth=(user, password), name=database)
 
     def check_connection(self) -> bool:
         try:
@@ -112,7 +112,6 @@ def get_graph() -> Optional[Py2NeoGraph]:
             NEO4J_URI,
             auth=(NEO4J_USER, NEO4J_PASSWORD),
             name=NEO4J_DATABASE,
-            timeout=5,
         )
         _ = _graph.service.kernel_version
         return _graph

--- a/summer_memory/quintuple_graph.py
+++ b/summer_memory/quintuple_graph.py
@@ -110,7 +110,7 @@ def get_graph():
 
             if grag_enabled and neo4j_uri and neo4j_user and neo4j_password:
                 try:
-                    _graph = Graph(neo4j_uri, auth=(neo4j_user, neo4j_password), name=neo4j_database, timeout=5)
+                    _graph = Graph(neo4j_uri, auth=(neo4j_user, neo4j_password), name=neo4j_database)
                     _graph.service.kernel_version
                     print("[GRAG] 成功连接到 Neo4j。")
                     GRAG_ENABLED = True


### PR DESCRIPTION
**孩子们，和我修一辈子记忆系统**

移除 py2neo.Graph() 构造函数中不支持的 timeout=5 参数，修复 GRAG 启动时 Neo4j 连接必定失败的问题
修复 main.py 中 GRAG_ENABLED 状态判断始终为 False 导致 Neo4j 连接状态误报为"失败"的问题

具体描述：
- timeout 参数不兼容：py2neo 2021.2.4（pyproject.toml 锁定 >=2021.2.3 的唯一可用版本）的 Graph() / GraphService.__init__() 仅接受user_agent、init_size、max_size、max_age、routing_refresh_ttl 五个 settings，不支持 timeout。传入后抛出 The following settings are not supported: {'timeout': 5}，导致启用 GRAG 的用户无法连接 Neo4j。

- GRAG_ENABLED 状态误报：main.py 中使用 from summer_memory.quintuple_graph import GRAG_ENABLED 在 get_graph() 调用前将 GRAG_ENABLED（此时为False）复制为本地变量。get_graph() 内部将模块级 GRAG_ENABLED 更新为 True 后，main.py 中的副本不会同步更新，导致即使Neo4j 实际连接成功，启动日志仍显示 Neo4j连接: 失败。

<img width="1719" height="502" alt="image" src="https://github.com/user-attachments/assets/4bfd2c9d-05e2-440d-a2bd-1310fd73eb5d" />
