### PR TITLE
feat: 支持 anthropic 协议并兼容第三方分发站，修复 live2d-only 空回复

### DIFF
--- a/apiserver/agentic_tool_loop.py
+++ b/apiserver/agentic_tool_loop.py
@@ -1441,6 +1441,37 @@ async def run_agentic_loop(
 
         # 5. 如果没有可执行的工具调用，循环结束
         if not actionable_calls:
+            # 模型只返回了 live2d 调用而没有文字内容时（Anthropic 常见行为），
+            # 需要将 live2d tool call 的结果回注并再调用一轮 LLM 来生成文字回复
+            if live2d_calls and not complete_text.strip() and use_native and round_num < max_rounds:
+                logger.info(f"[AgenticLoop] Round {round_num}: 模型仅返回 live2d 调用无正文，"
+                            f"回注 tool result 继续下一轮获取文字回复")
+                # 构造 assistant message + tool results for live2d calls
+                assistant_msg = {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": c.get("_tool_call_id", f"call_{i}"),
+                            "type": "function",
+                            "function": {
+                                "name": c.get("_original_name", ""),
+                                "arguments": c.get("_original_args", "{}"),
+                            },
+                        }
+                        for i, c in enumerate(live2d_calls)
+                    ],
+                }
+                messages.append(assistant_msg)
+                for c in live2d_calls:
+                    messages.append({
+                        "role": "tool",
+                        "tool_call_id": c.get("_tool_call_id", ""),
+                        "content": "已执行",
+                    })
+                yield _format_sse_event("round_end", {"round": round_num, "has_more": True})
+                continue
+
             t_round_elapsed = _time.monotonic() - t_round_start
             t_total_elapsed = _time.monotonic() - t_loop_start
             logger.info(f"[AgenticLoop] Round {round_num}: 无工具调用，循环结束 "

--- a/apiserver/context_compressor.py
+++ b/apiserver/context_compressor.py
@@ -299,7 +299,10 @@ def _get_compress_llm_params() -> Dict:
         }
     cfg = get_config()
     params: Dict = {"api_key": cfg.api.api_key}
-    if cfg.api.base_url:
+    if cfg.api.api_format == "anthropic":
+        if cfg.api.base_url and "anthropic.com" not in cfg.api.base_url:
+            params["api_base"] = cfg.api.base_url.rstrip("/")
+    elif cfg.api.base_url:
         params["api_base"] = cfg.api.base_url.rstrip("/") + "/"
     return params
 
@@ -308,7 +311,10 @@ def _get_compress_model_name() -> str:
     """获取压缩模型名称（LiteLLM 格式）"""
     if naga_auth.is_authenticated():
         return f"openai/{COMPRESS_MODEL}"
-    base_url = (get_config().api.base_url or "").lower()
+    cfg = get_config()
+    if cfg.api.api_format == "anthropic":
+        return f"anthropic/{COMPRESS_MODEL}"
+    base_url = (cfg.api.base_url or "").lower()
     if "openai.com" in base_url:
         return COMPRESS_MODEL
     return f"openai/{COMPRESS_MODEL}"

--- a/apiserver/intent_router.py
+++ b/apiserver/intent_router.py
@@ -175,7 +175,10 @@ def _get_router_llm_params() -> Dict:
         }
     cfg = get_config()
     params: Dict = {"api_key": cfg.api.api_key}
-    if cfg.api.base_url:
+    if cfg.api.api_format == "anthropic":
+        if cfg.api.base_url and "anthropic.com" not in cfg.api.base_url:
+            params["api_base"] = cfg.api.base_url.rstrip("/")
+    elif cfg.api.base_url:
         params["api_base"] = cfg.api.base_url.rstrip("/") + "/"
     return params
 
@@ -184,7 +187,10 @@ def _get_router_model_name() -> str:
     """获取路由模型名称（LiteLLM 格式）"""
     if naga_auth.is_authenticated():
         return f"openai/{ROUTER_MODEL}"
-    base_url = (get_config().api.base_url or "").lower()
+    cfg = get_config()
+    if cfg.api.api_format == "anthropic":
+        return f"anthropic/{ROUTER_MODEL}"
+    base_url = (cfg.api.base_url or "").lower()
     if "openai.com" in base_url:
         return ROUTER_MODEL
     return f"openai/{ROUTER_MODEL}"

--- a/apiserver/llm_service.py
+++ b/apiserver/llm_service.py
@@ -49,11 +49,12 @@ class LLMService:
         """初始化 LiteLLM 配置"""
         try:
             cfg = get_config()
-            # 配置 LiteLLM 使用自定义 base_url
             litellm.api_key = cfg.api.api_key
-            # 设置自定义端点（如果不是标准 OpenAI）
-            if cfg.api.base_url and "openai.com" not in cfg.api.base_url:
-                litellm.api_base = cfg.api.base_url.rstrip("/") + "/"
+            # Anthropic 格式下不设置全局 api_base，由每次调用的参数传递
+            # 避免全局 base 污染导致请求被路由到错误的端点
+            if cfg.api.api_format != "anthropic":
+                if cfg.api.base_url and "openai.com" not in cfg.api.base_url:
+                    litellm.api_base = cfg.api.base_url.rstrip("/") + "/"
             self._initialized = True
             logger.info("LLM服务 (LiteLLM) 初始化成功")
         except Exception as e:
@@ -70,13 +71,20 @@ class LLMService:
         cfg = get_config()
         model = model or cfg.api.model
         base_url = (base_url or cfg.api.base_url or "").lower()
+        api_format = cfg.api.api_format
 
         # NagaModel 网关：使用用户选择的模型名，由服务端路由
         # 需要 openai/ 前缀让 LiteLLM 识别为 OpenAI 兼容提供商
         if naga_auth.is_authenticated():
             return f"openai/{model or 'default'}"
 
-        # 根据 base_url 判断提供商，添加正确的前缀
+        # Anthropic 格式：使用 anthropic/ 前缀让 LiteLLM 走 Anthropic Messages API
+        if api_format == "anthropic":
+            if not model.startswith("anthropic/"):
+                return f"anthropic/{model}"
+            return model
+
+        # OpenAI 格式：根据 base_url 判断提供商，添加正确的前缀
         if "deepseek" in base_url:
             if not model.startswith("deepseek/"):
                 return f"deepseek/{model}"
@@ -100,6 +108,12 @@ class LLMService:
                 "extra_body": {"user_token": token},
             }
         cfg = get_config()
+        if cfg.api.api_format == "anthropic":
+            params: Dict[str, Any] = {"api_key": cfg.api.api_key}
+            if cfg.api.base_url and "anthropic.com" not in cfg.api.base_url:
+                # LiteLLM 会自动追加 /v1/messages，不要加尾部 /
+                params["api_base"] = cfg.api.base_url.rstrip("/")
+            return params
         return {
             "api_key": cfg.api.api_key,
             "api_base": cfg.api.base_url.rstrip("/") + "/" if cfg.api.base_url else None,
@@ -117,10 +131,16 @@ class LLMService:
                 "extra_body": {"user_token": token},
             }
         cfg = get_config()
+        effective_key = api_key or cfg.api.api_key
+        effective_base = api_base or cfg.api.base_url
+        if cfg.api.api_format == "anthropic" and not api_base:
+            params: Dict[str, Any] = {"api_key": effective_key}
+            if effective_base and "anthropic.com" not in effective_base:
+                params["api_base"] = effective_base.rstrip("/")
+            return params
         return {
-            "api_key": api_key or cfg.api.api_key,
-            "api_base": (api_base.rstrip("/") + "/" if api_base else None)
-            or (cfg.api.base_url.rstrip("/") + "/" if cfg.api.base_url else None),
+            "api_key": effective_key,
+            "api_base": (effective_base.rstrip("/") + "/" if effective_base else None),
         }
 
     async def get_response(self, prompt: str, temperature: float = 0.7) -> str:
@@ -294,7 +314,8 @@ class LLMService:
                 }
                 if tools:
                     call_params["tools"] = tools
-                    call_params["parallel_tool_calls"] = True
+                    if get_config().api.api_format != "anthropic":
+                        call_params["parallel_tool_calls"] = True
 
                 response = await acompletion(**call_params)
 

--- a/config.json.example
+++ b/config.json.example
@@ -11,6 +11,7 @@
     "api_key": "your-api-key-here",
     "base_url": "https://api.deepseek.com",
     "model": "deepseek-v3.2",
+    "api_format": "openai",
     "max_tokens": 8192,
     "context_load_days": 3
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "websockets>=15.0",
     # ---------- LLM / 对话 ----------
     "openai>=2.8.0",
+    "anthropic>=0.42.0",
     "litellm>=1.80.0",
     "tiktoken>=0.11.0",
     "langchain-openai>=1.1.0",

--- a/summer_memory/quintuple_extractor.py
+++ b/summer_memory/quintuple_extractor.py
@@ -13,19 +13,65 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
 from system.config import config
 from openai import OpenAI, AsyncOpenAI
 
-# 初始化OpenAI客户端
-client = OpenAI(
-    api_key=config.api.api_key,
-    base_url=config.api.base_url
-)
+_is_anthropic = config.api.api_format == "anthropic"
 
-async_client = AsyncOpenAI(
-    api_key=config.api.api_key,
-    base_url=config.api.base_url
-)
+if _is_anthropic:
+    import httpx
+    from anthropic import Anthropic, AsyncAnthropic
+    _anthropic_base_url = config.api.base_url.rstrip("/") if config.api.base_url and "anthropic.com" not in config.api.base_url else None
+    _anthropic_timeout = httpx.Timeout(timeout=300.0, connect=10.0)
+    _anthropic_client = Anthropic(
+        api_key=config.api.api_key,
+        base_url=_anthropic_base_url,
+        timeout=_anthropic_timeout,
+    )
+    _async_anthropic_client = AsyncAnthropic(
+        api_key=config.api.api_key,
+        base_url=_anthropic_base_url,
+        timeout=_anthropic_timeout,
+    )
+    client = None
+    async_client = None
+else:
+    _anthropic_client = None
+    _async_anthropic_client = None
+    client = OpenAI(
+        api_key=config.api.api_key,
+        base_url=config.api.base_url
+    )
+    async_client = AsyncOpenAI(
+        api_key=config.api.api_key,
+        base_url=config.api.base_url
+    )
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
+
+
+def _anthropic_chat(system: str, user: str, *, temperature: float = 0.3,
+                    max_tokens: int | None = None) -> str:
+    """同步 Anthropic Messages API 调用，返回文本内容"""
+    resp = _anthropic_client.messages.create(
+        model=config.api.model,
+        system=system,
+        messages=[{"role": "user", "content": user}],
+        max_tokens=max_tokens or config.api.max_tokens,
+        temperature=temperature,
+    )
+    return resp.content[0].text
+
+
+async def _anthropic_chat_async(system: str, user: str, *, temperature: float = 0.3,
+                                max_tokens: int | None = None) -> str:
+    """异步 Anthropic Messages API 调用，返回文本内容"""
+    resp = await _async_anthropic_client.messages.create(
+        model=config.api.model,
+        system=system,
+        messages=[{"role": "user", "content": user}],
+        max_tokens=max_tokens or config.api.max_tokens,
+        temperature=temperature,
+    )
+    return resp.content[0].text
 
 
 # 定义五元组的Pydantic模型
@@ -181,16 +227,24 @@ async def _extract_quintuples_async_fallback(text):
 
     for attempt in range(max_retries + 1):
         try:
-            response = await async_client.chat.completions.create(
-                model=config.api.model,
-                messages=[{"role": "user", "content": prompt}],
-                max_tokens=config.api.max_tokens,
-                temperature=0.3,
-                timeout=600 + (attempt * 20)
-            )
-            
-            content = response.choices[0].message.content.strip()
-            
+            if _is_anthropic:
+                content = await _anthropic_chat_async(
+                    system="你是一个专业的中文文本信息抽取专家。",
+                    user=prompt,
+                    temperature=0.3,
+                )
+            else:
+                response = await async_client.chat.completions.create(
+                    model=config.api.model,
+                    messages=[{"role": "user", "content": prompt}],
+                    max_tokens=config.api.max_tokens,
+                    temperature=0.3,
+                    timeout=600 + (attempt * 20)
+                )
+                content = response.choices[0].message.content.strip()
+
+            content = content.strip()
+
             # 尝试解析JSON
             try:
                 quintuples = json.loads(content)
@@ -198,7 +252,6 @@ async def _extract_quintuples_async_fallback(text):
                 return [tuple(t) for t in quintuples if len(t) == 5]
             except json.JSONDecodeError:
                 logger.error(f"JSON解析失败，原始内容: {content[:200]}")
-                # 尝试直接提取数组
                 if '[' in content and ']' in content:
                     start = content.index('[')
                     end = content.rindex(']') + 1
@@ -216,7 +269,8 @@ async def _extract_quintuples_async_fallback(text):
 
 def extract_quintuples(text):
     """同步版本的五元组提取"""
-    # 首先尝试使用结构化输出
+    if _is_anthropic:
+        return _extract_quintuples_fallback(text)
     return _extract_quintuples_structured(text)
 
 
@@ -354,16 +408,24 @@ def _extract_quintuples_fallback(text):
 
     for attempt in range(max_retries + 1):
         try:
-            response = client.chat.completions.create(
-                model=config.api.model,
-                messages=[{"role": "user", "content": prompt}],
-                max_tokens=config.api.max_tokens,
-                temperature=0.5,
-                timeout=600 + (attempt * 20)
-            )
+            if _is_anthropic:
+                content = _anthropic_chat(
+                    system="你是一个专业的中文文本信息抽取专家。",
+                    user=prompt,
+                    temperature=0.5,
+                )
+            else:
+                response = client.chat.completions.create(
+                    model=config.api.model,
+                    messages=[{"role": "user", "content": prompt}],
+                    max_tokens=config.api.max_tokens,
+                    temperature=0.5,
+                    timeout=600 + (attempt * 20)
+                )
+                content = response.choices[0].message.content.strip()
 
-            content = response.choices[0].message.content.strip()
-            
+            content = content.strip()
+
             # 尝试解析JSON
             try:
                 quintuples = json.loads(content)
@@ -371,7 +433,6 @@ def _extract_quintuples_fallback(text):
                 return [tuple(t) for t in quintuples if len(t) == 5]
             except json.JSONDecodeError:
                 logger.error(f"JSON解析失败，原始内容: {content[:200]}")
-                # 尝试直接提取数组
                 if '[' in content and ']' in content:
                     start = content.index('[')
                     end = content.rindex(']') + 1

--- a/system/config.py
+++ b/system/config.py
@@ -275,6 +275,7 @@ class APIConfig(BaseModel):
     api_key: str = Field(default="sk-placeholder-key-not-set", description="API密钥")
     base_url: str = Field(default="https://api.deepseek.com/v1", description="API基础URL")
     model: str = Field(default="deepseek-v3.2", description="使用的模型名称")
+    api_format: str = Field(default="openai", description="API调用格式：openai 或 anthropic")
     temperature: float = Field(default=0.7, ge=0.0, le=2.0, description="温度参数")
     max_tokens: int = Field(default=10000, ge=1, le=32768, description="最大token数")
     max_history_rounds: int = Field(default=100, ge=1, le=200, description="最大历史轮数")
@@ -282,6 +283,14 @@ class APIConfig(BaseModel):
     context_load_days: int = Field(default=3, ge=1, le=30, description="加载历史上下文的天数")
     context_parse_logs: bool = Field(default=True, description="是否从日志文件解析上下文")
     applied_proxy: bool = Field(default=True, description="是否应用代理")
+
+    @field_validator("api_format")
+    @classmethod
+    def validate_api_format(cls, v):
+        valid_formats = ["openai", "anthropic"]
+        if v.lower() not in valid_formats:
+            raise ValueError(f"api_format 必须是以下之一: {valid_formats}")
+        return v.lower()
 
 
 class APIServerConfig(BaseModel):

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.11.*"
 resolution-markers = [
     "sys_platform == 'darwin'",
@@ -97,6 +97,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.94.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/f2/fb4a04ff676742588a41f94dd318883d6d77e88e2b5e20b664ae3bf20e1b/anthropic-0.94.1.tar.gz", hash = "sha256:96c7033069c16074f90638dff8bf1f1616f9eefeb8ef7d1b0df4a0393ab34685", size = 654451, upload-time = "2026-04-13T18:08:18.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/18/6d5b5948cbe450d3c98336c8a8c4804aedb3ab24fa37922d05063f8ba266/anthropic-0.94.1-py3-none-any.whl", hash = "sha256:58fb20dc60f35e75a5a82a1c73a3e196ac3b18ff2ed4826cba345f4adb78919d", size = 627710, upload-time = "2026-04-13T18:08:19.629Z" },
 ]
 
 [[package]]
@@ -389,6 +408,15 @@ wheels = [
 ]
 
 [[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
 name = "durationpy"
 version = "0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -567,7 +595,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/cb/48e964c452ca2b92175a9b2dca037a553036cb053ba69e284650ce755f13/greenlet-3.3.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:e29f3018580e8412d6aaf5641bb7745d38c85228dacf51a73bd4e26ddf2a6a8e", size = 274908, upload-time = "2025-12-04T14:23:26.435Z" },
     { url = "https://files.pythonhosted.org/packages/28/da/38d7bff4d0277b594ec557f479d65272a893f1f2a716cad91efeb8680953/greenlet-3.3.0-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a687205fb22794e838f947e2194c0566d3812966b41c78709554aa883183fb62", size = 577113, upload-time = "2025-12-04T14:50:05.493Z" },
     { url = "https://files.pythonhosted.org/packages/3c/f2/89c5eb0faddc3ff014f1c04467d67dee0d1d334ab81fadbf3744847f8a8a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4243050a88ba61842186cb9e63c7dfa677ec146160b0efd73b855a3d9c7fcf32", size = 590338, upload-time = "2025-12-04T14:57:41.136Z" },
-    { url = "https://files.pythonhosted.org/packages/80/d7/db0a5085035d05134f8c089643da2b44cc9b80647c39e93129c5ef170d8f/greenlet-3.3.0-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:670d0f94cd302d81796e37299bcd04b95d62403883b24225c6b5271466612f45", size = 601098, upload-time = "2025-12-04T15:07:11.898Z" },
     { url = "https://files.pythonhosted.org/packages/dc/a6/e959a127b630a58e23529972dbc868c107f9d583b5a9f878fb858c46bc1a/greenlet-3.3.0-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6cb3a8ec3db4a3b0eb8a3c25436c2d49e3505821802074969db017b87bc6a948", size = 590206, upload-time = "2025-12-04T14:26:01.254Z" },
     { url = "https://files.pythonhosted.org/packages/48/60/29035719feb91798693023608447283b266b12efc576ed013dd9442364bb/greenlet-3.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:2de5a0b09eab81fc6a382791b995b1ccf2b172a9fec934747a7a23d2ff291794", size = 1550668, upload-time = "2025-12-04T15:04:22.439Z" },
     { url = "https://files.pythonhosted.org/packages/0a/5f/783a23754b691bfa86bd72c3033aa107490deac9b2ef190837b860996c9f/greenlet-3.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:4449a736606bd30f27f8e1ff4678ee193bc47f6ca810d705981cfffd6ce0d8c5", size = 1615483, upload-time = "2025-12-04T14:27:28.083Z" },
@@ -1140,6 +1167,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
     { name = "aiohttp" },
+    { name = "anthropic" },
     { name = "apscheduler" },
     { name = "charset-normalizer" },
     { name = "chromadb" },
@@ -1185,6 +1213,7 @@ test = [
 requires-dist = [
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "aiohttp", specifier = ">=3.12.0" },
+    { name = "anthropic", specifier = ">=0.42.0" },
     { name = "apscheduler", specifier = ">=3.11.0" },
     { name = "charset-normalizer", specifier = ">=3.4.0" },
     { name = "chromadb", specifier = ">=0.5.0" },


### PR DESCRIPTION
本次改动:
新增 api.api_format 配置（openai / anthropic），并在配置模型中做合法性校验
LLM 主调用链按 api_format 动态切换 provider 前缀与参数拼装
Anthropic 模式下改为按请求注入 api_base，避免全局 litellm.api_base 污染
兼容第三方 Anthropic 分发站（自定义 base_url）
同步修复 context_compressor、intent_router 的 Anthropic 参数处理
quintuple_extractor 增加 Anthropic SDK 分支并处理长超时限制
修复 agentic loop 在“仅 live2d 工具调用”场景下提前结束导致无文本回复的问题

效果:
支持通过配置无缝切换 OpenAI / Anthropic 调用格式
Anthropic 第三方分发站可正常完成流式与非流式请求
工具调用链路在 Anthropic 下行为更稳定，减少空回复场景

影响范围:
配置系统：system/config.py、config.json.example
LLM 调用：apiserver/llm_service.py
路由/压缩：apiserver/intent_router.py、apiserver/context_compressor.py
记忆提取：summer_memory/quintuple_extractor.py
Agentic 循环：apiserver/agentic_tool_loop.py

新的 config.json 填写方式（示例）:
A. 使用 OpenAI 兼容接口
```json
{
  "api": {
    "api_key": "your-openai-or-openai-compatible-key",
    "base_url": "https://api.openai.com/v1",
    "model": "gpt-4o-mini",
    "api_format": "openai",
    "max_tokens": 8192,
    "context_load_days": 3
  }
}
```
B. 使用 Anthropic 官方接口
```json
{
  "api": {
    "api_key": "sk-ant-xxxx",
    "base_url": "https://api.anthropic.com",
    "model": "claude-sonnet-4-20250514",
    "api_format": "anthropic",
    "max_tokens": 8192,
    "context_load_days": 3
  }
}
```
C. 使用第三方 Anthropic 分发站
```json
{
  "api": {
    "api_key": "your-distributor-key",
    "base_url": "https://api.xxx.com",
    "model": "claude-sonnet-4-6",
    "api_format": "anthropic",
    "max_tokens": 8192,
    "context_load_days": 3
  }
}
```