### PR TITLE
  fix: unify runtime config path and sync root config on startup

### DIFF
--- a/main.py
+++ b/main.py
@@ -89,7 +89,7 @@ if not hasattr(socket, 'EAI_ADDRFAMILY'):
 
 # 本地模块导入
 from system.system_checker import run_system_check, run_quick_check
-from system.config import config, AI_NAME
+from system.config import config, AI_NAME, get_config_path, sync_source_config_to_runtime
 
 # V14版本已移除早期拦截器，采用运行时猴子补丁
 
@@ -628,7 +628,7 @@ def check_and_update_if_needed() -> bool:
     from datetime import datetime
     import json5
 
-    config_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config.json")
+    config_file = get_config_path()
 
     if not os.path.exists(config_file):
         return False
@@ -694,6 +694,8 @@ def _lazy_init_services():
     """延迟初始化服务 - 在需要时才初始化"""
     global service_manager, n
     if not hasattr(_lazy_init_services, '_initialized'):
+        sync_source_config_to_runtime()
+
         # 初始化服务管理器
         service_manager = ServiceManager()
         service_manager.start_background_services()
@@ -777,6 +779,7 @@ if __name__ == "__main__":
         sys.exit(0 if success else 1)
 
     # 检查上次系统检测时间，如果超过7天则执行更新
+    sync_source_config_to_runtime()
     check_and_update_if_needed()
 
     # 启动前清理占用端口的进程

--- a/system/config.py
+++ b/system/config.py
@@ -8,6 +8,7 @@ import os
 import sys
 import json
 import re
+import shutil
 try:
     import tomllib
 except ModuleNotFoundError:
@@ -78,6 +79,32 @@ def get_config_path() -> str:
     target = d / "config.json"
     _migrate_config_if_needed(target)
     return str(target)
+
+
+def sync_source_config_to_runtime() -> bool:
+    """源码运行时将项目根目录 config.json 同步到用户数据目录。"""
+    if IS_PACKAGED:
+        return False
+
+    source = Path(__file__).parent.parent / "config.json"
+    if not source.exists():
+        return False
+
+    target = Path(get_data_dir()) / "config.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        source_bytes = source.read_bytes()
+        target_bytes = target.read_bytes() if target.exists() else None
+        if target_bytes == source_bytes:
+            return False
+
+        shutil.copy2(source, target)
+        print(f"已同步源码配置: {source} → {target}")
+        return True
+    except Exception as e:
+        print(f"警告：同步源码配置失败: {e}")
+        return False
 
 from pydantic import BaseModel, Field, field_validator
 from charset_normalizer import from_path

--- a/system/config.py
+++ b/system/config.py
@@ -8,7 +8,6 @@ import os
 import sys
 import json
 import re
-import shutil
 try:
     import tomllib
 except ModuleNotFoundError:
@@ -81,8 +80,66 @@ def get_config_path() -> str:
     return str(target)
 
 
+_RUNTIME_PROTECTED_CONFIG_PATHS = {
+    "system_check",
+}
+
+_MODEL_SYNC_CONFIG_PATHS = {
+    "api.model",
+    "api.api_format",
+    "voice_realtime.provider",
+    "voice_realtime.model",
+    "voice_realtime.tts_model",
+    "voice_realtime.asr_model",
+    "computer_control.model",
+    "computer_control.grounding_model",
+    "embedding.model",
+    "guide_engine.embedding_api_model",
+    "guide_engine.game_guide_llm_api_model",
+    "guide_engine.game_guide_llm_api_type",
+    "openclaw.default_model",
+}
+
+
+def _merge_source_config_into_runtime(source_value, target_value, path: str = ""):
+    if path in _RUNTIME_PROTECTED_CONFIG_PATHS:
+        return target_value, False
+
+    if path in _MODEL_SYNC_CONFIG_PATHS:
+        if target_value != source_value:
+            return source_value, True
+        return target_value, False
+
+    if isinstance(source_value, dict):
+        target_dict = target_value if isinstance(target_value, dict) else {}
+        merged = dict(target_dict)
+        changed = not isinstance(target_value, dict)
+
+        for key, source_child in source_value.items():
+            child_path = f"{path}.{key}" if path else key
+            if key in target_dict:
+                merged_child, child_changed = _merge_source_config_into_runtime(
+                    source_child,
+                    target_dict[key],
+                    child_path,
+                )
+                if child_changed:
+                    merged[key] = merged_child
+                    changed = True
+            else:
+                merged[key] = source_child
+                changed = True
+
+        return merged, changed
+
+    if target_value is None:
+        return source_value, True
+
+    return target_value, False
+
+
 def sync_source_config_to_runtime() -> bool:
-    """源码运行时将项目根目录 config.json 同步到用户数据目录。"""
+    """源码运行时同步配置结构到用户数据目录，同时强制刷新模型相关配置。"""
     if IS_PACKAGED:
         return False
 
@@ -94,13 +151,23 @@ def sync_source_config_to_runtime() -> bool:
     target.parent.mkdir(parents=True, exist_ok=True)
 
     try:
-        source_bytes = source.read_bytes()
-        target_bytes = target.read_bytes() if target.exists() else None
-        if target_bytes == source_bytes:
+        with open(source, "r", encoding=detect_file_encoding(str(source))) as source_file:
+            source_config = json5.load(source_file)
+
+        if target.exists():
+            with open(target, "r", encoding=detect_file_encoding(str(target))) as target_file:
+                target_config = json5.load(target_file)
+        else:
+            target_config = {}
+
+        merged_config, changed = _merge_source_config_into_runtime(source_config, target_config)
+        if not changed:
             return False
 
-        shutil.copy2(source, target)
-        print(f"已同步源码配置: {source} → {target}")
+        with open(target, "w", encoding="utf-8") as target_file:
+            json.dump(merged_config, target_file, ensure_ascii=False, indent=2)
+
+        print(f"已同步源码配置结构: {source} → {target}")
         return True
     except Exception as e:
         print(f"警告：同步源码配置失败: {e}")

--- a/system/system_checker.py
+++ b/system/system_checker.py
@@ -25,12 +25,12 @@ class SystemChecker:
         self.project_root = Path(__file__).parent.parent  # 指向项目根目录
         self.venv_path = self.project_root / "venv"  # 更新为venv目录
         self.requirements_file = self.project_root / "requirements.txt"
-        self.config_file = self.project_root / "config.json"
         self.pyproject_file = self.project_root / "pyproject.toml"
         self.results = {}
 
         # 需要检测的端口 - 从config读取
-        from system.config import get_all_server_ports
+        from system.config import get_all_server_ports, get_config_path
+        self.config_file = Path(get_config_path())
         all_ports = get_all_server_ports()
         self.required_ports = [
             all_ports["api_server"],


### PR DESCRIPTION
  ## Summary
  - 在源码启动时，将项目根目录 `config.json` 同步到运行时用户配置目录，确保实际启动配置与仓库配置一致
  - 统一运行时配置读取路径，改为通过 `get_config_path()` 使用 AppData/Roaming 下的配置
  - 修复 `main.py` 和 `system_checker.py` 仍直接读写项目根目录 `config.json` 导致的配置来源不一致问题

  ## Changes
  - 在 `system/config.py` 中新增源码启动配置同步逻辑
  - 在 `main.py` 启动流程中加入启动前配置同步
  - 将 `check_and_update_if_needed()` 改为读取运行时配置路径
  - 将 `system/system_checker.py` 的配置读写切换到运行时配置文件

  ## Why
  当前项目的主配置逻辑已经切到用户数据目录，但仍有部分启动/检测逻辑直接使用仓库根目录 `config.json`，会导致实际运行配置与检测状态分散在两个位置。这个PR将启动阶段的配置来源统一到运行时配置文件，并保证源码调试时根目录配置会覆盖同步到用户目录。
