### PR TITLE
Refactor: 统一运行时配置目录并修正服务端口/语音检测链路

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -9,36 +9,47 @@
   },
   "api": {
     "api_key": "your-api-key-here",
-    "base_url": "https://api.deepseek.com",
+    "base_url": "https://api.deepseek.com/v1",
     "model": "deepseek-v3.2",
     "api_format": "openai",
-    "max_tokens": 8192,
-    "context_load_days": 3
+    "max_tokens": 10000,
+    "context_load_days": 3,
+    "applied_proxy": true
   },
   "api_server": {
     "enabled": true,
+    "host": "127.0.0.1",
     "port": 8000,
+    "auto_start": true,
     "docs_enabled": true
   },
-  "agentserver": {
-    "enabled": true
-  },
-  "mcpserver": {
+  "agent_server": {
     "enabled": true,
+    "host": "127.0.0.1",
+    "port": 8001
+  },
+  "mcp_server": {
+    "enabled": true,
+    "host": "127.0.0.1",
+    "port": 8003,
     "agent_discovery": true
   },
   "grag": {
     "enabled": true,
     "auto_extract": true,
     "context_length": 5,
+    "neo4j_uri": "neo4j://127.0.0.1:7687",
     "neo4j_user": "neo4j",
+    "neo4j_password": "your_password",
     "neo4j_database": "neo4j",
     "extraction_timeout": 12,
     "extraction_retries": 2,
     "base_timeout": 15
   },
   "handoff": {
-    "max_loop_stream": 5
+    "max_loop_stream": 5,
+    "max_loop_non_stream": 5,
+    "show_output": false
   },
   "browser": {
     "playwright_headless": false
@@ -49,77 +60,149 @@
     "default_voice": "zh-CN-XiaoxiaoNeural",
     "default_format": "mp3",
     "default_speed": 1.0,
+    "default_language": "zh-CN",
     "remove_filter": false,
+    "expand_api": true,
     "require_api_key": false
   },
-  "game": {
-    "enabled": false,
-    "skip_on_error": true
+  "asr": {
+    "port": 5060,
+    "sample_rate_in": 48000,
+    "frame_ms": 30,
+    "resample_to": 16000,
+    "vad_threshold": 0.7,
+    "silence_ms": 420,
+    "noise_reduce": true,
+    "engine": "local_funasr",
+    "local_model_path": "./utilss/models/SenseVoiceSmall",
+    "vad_model_path": "silero_vad.onnx",
+    "api_key_required": false,
+    "callback_url": null,
+    "ws_broadcast": false
   },
-  "voice_realtime": {
-    "enabled": false,
-    "provider": "qwen",
-    "model": "qwen3-omni-flash-realtime",
-    "tts_model": "qwen-tts-realtime",
-    "asr_model": "qwen3-asr-realtime",
-    "voice": "Cherry",
-    "voice_mode": "auto",
-    "tts_voice": "zh-CN-XiaoyiNeural",
-    "input_sample_rate": 16000,
-    "vad_threshold": 0.02,
-    "min_user_interval": 2.0,
-    "cooldown_duration": 1.0,
-    "max_user_speech": 30.0,
-    "debug": false,
-    "integrate_with_memory": true,
-    "use_api_server": true
+  "filter": {
+    "filter_think_tags": true,
+    "clean_output": true
   },
-  "weather": {
-    "api_key": "your-weather-api-key-or-leave-empty"
+  "difficulty": {
+    "enabled": false,
+    "use_small_model": false,
+    "pre_assessment": false,
+    "assessment_timeout": 1.0,
+    "threshold_simple": 2,
+    "threshold_medium": 4,
+    "threshold_hard": 6
+  },
+  "scoring": {
+    "enabled": false,
+    "score_range": [1, 5],
+    "score_threshold": 2,
+    "similarity_threshold": 0.85,
+    "max_user_preferences": 3,
+    "default_preferences": ["逻辑清晰准确", "实用性强", "创新思维"],
+    "penalty_for_similar": 1,
+    "min_results_required": 2,
+    "strict_filtering": true
   },
   "mqtt": {
     "enabled": false,
-    "broker": "mqtt-broker-address",
+    "broker": "localhost",
     "port": 1883,
-    "topic": "naga/agent/topic",
-    "client_id": "naga-agent-client",
-    "username": "mqtt-username",
+    "topic": "/test/topic",
+    "client_id": "naga_mqtt_client",
+    "username": "",
+    "password": "",
     "keepalive": 60,
     "qos": 1
   },
   "ui": {
     "user_name": "用户",
-    "bg_alpha": 0.81,
+    "bg_alpha": 0.5,
+    "window_bg_alpha": 110,
+    "mac_btn_size": 36,
     "mac_btn_margin": 16,
     "mac_btn_gap": 12,
     "animation_duration": 600
   },
+  "live2d": {
+    "enabled": true,
+    "model_path": "ui/live2d_local/live2d_models/kasane_teto/kasane_teto.model3.json",
+    "fallback_image": "ui/img/standby.png",
+    "auto_switch": true,
+    "animation_enabled": true,
+    "touch_interaction": true,
+    "scale_factor": 1.0,
+    "lip_sync_enabled": true,
+    "lip_sync_smooth_factor": 0.3,
+    "lip_sync_volume_scale": 1.5,
+    "lip_sync_volume_threshold": 0.01
+  },
+  "floating": {
+    "enabled": false
+  },
+  "voice_realtime": {
+    "enabled": false,
+    "provider": "qwen",
+    "api_key": "",
+    "model": "qwen3-omni-flash-realtime",
+    "tts_model": "qwen-tts-realtime",
+    "asr_model": "qwen3-asr-realtime",
+    "voice": "Cherry",
+    "input_sample_rate": 16000,
+    "output_sample_rate": 24000,
+    "chunk_size_ms": 200,
+    "vad_threshold": 0.02,
+    "echo_suppression": true,
+    "min_user_interval": 2.0,
+    "cooldown_duration": 1.0,
+    "max_user_speech": 30.0,
+    "debug": false,
+    "integrate_with_memory": true,
+    "show_in_chat": true,
+    "use_api_server": false,
+    "voice_mode": "auto",
+    "asr_host": "localhost",
+    "asr_port": 5000,
+    "record_duration": 10,
+    "tts_voice": "zh-CN-XiaoyiNeural",
+    "tts_host": "localhost",
+    "tts_port": 5061,
+    "auto_play": true,
+    "interrupt_playback": true
+  },
   "naga_portal": {
-    "portal_url": "https://portal.example.com",
-    "username": "your-portal-username"
+    "portal_url": "https://naga.furina.chat/",
+    "username": "",
+    "password": "",
+    "request_timeout": 30,
+    "login_path": "/api/user/login",
+    "turnstile_param": "",
+    "login_username_key": "username",
+    "login_password_key": "password",
+    "login_payload_mode": "json"
   },
   "online_search": {
-    "searxng_url": "https://searxng.example.com",
-    "engines": [
-      "google"
-    ],
-    "num_results": 5
+    "searxng_url": "http://localhost:8080",
+    "engines": ["google"],
+    "num_results": 5,
+    "search_api_key": "",
+    "search_api_base": "https://api.search.brave.com/res/v1/web/search"
   },
   "openclaw": {
-    "enabled": false,
     "gateway_port": 20789,
     "gateway_url": "http://127.0.0.1:20789",
+    "token": null,
     "timeout": 120,
+    "default_model": null,
     "default_channel": "last",
+    "enabled": false,
     "feishu": {
       "enabled": false,
       "app_id": "",
       "app_secret": "",
       "dm_policy": "open",
       "group_policy": "allowlist",
-      "allow_from": [
-        "*"
-      ],
+      "allow_from": ["*"],
       "doc_owner_open_id": null
     }
   },
@@ -133,60 +216,74 @@
     },
     "qq": {
       "enabled": false,
-      "user_qq": ""
+      "binding_target": "",
+      "user_qq": "",
+      "qq_email": "",
+      "email_verification_code": "",
+      "binding_verified": false,
+      "binding_verified_email": ""
     }
+  },
+  "naga_business": {
+    "forum_api_url": "http://62.234.131.204:30031",
+    "internal_secret": "",
+    "enabled": false
+  },
+  "telemetry": {
+    "enabled": true,
+    "upload_enabled": true,
+    "upload_url": "",
+    "flush_interval_seconds": 60,
+    "upload_timeout_seconds": 10,
+    "batch_size": 50,
+    "max_queue_events": 5000,
+    "max_queue_bytes": 8388608
   },
   "computer_control": {
     "enabled": true,
-    "model_url": "https://api.example.com",
+    "model": "gemini-2.5-flash",
+    "model_url": "https://open.bigmodel.cn/api/paas/v4",
     "api_key": "",
     "grounding_model": "gemini-2.5-flash",
-    "grounding_url": "https://api.example.com",
+    "grounding_url": "https://open.bigmodel.cn/api/paas/v4",
     "grounding_api_key": "",
     "screen_width": 1920,
     "screen_height": 1080,
     "max_dim_size": 1920,
+    "dpi_awareness": true,
     "safe_mode": true
   },
   "guide_engine": {
     "enabled": true,
     "gamedata_dir": "./data",
-    "embedding_api_model": "text-embedding-3-small",
-    "neo4j_uri": "neo4j://localhost:7687",
+    "embedding_api_base_url": null,
+    "embedding_api_key": null,
+    "embedding_api_model": null,
+    "game_guide_llm_api_base_url": null,
+    "game_guide_llm_api_key": null,
+    "game_guide_llm_api_model": null,
+    "game_guide_llm_api_type": "openai",
+    "prompt_dir": "./guide_engine/game_prompts",
+    "neo4j_uri": "neo4j://127.0.0.1:7687",
     "neo4j_user": "neo4j",
-    "screenshot_monitor_index": 1
+    "neo4j_password": "your_password",
+    "screenshot_monitor_index": 1,
+    "auto_screenshot_on_guide": false
   },
   "memory_server": {
-    "url": "http://localhost:8000",
-    "token": null
+    "url": "http://localhost:8004",
+    "token": null,
+    "space_id": null
   },
   "embedding": {
     "model": "tongyi-embedding",
-    "api_base": ""
-  },
-  "crawl4ai": {
-    "headless": true,
-    "timeout": 30000,
-    "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
-    "viewport_width": 1280,
-    "viewport_height": 720
-  },
-  "live2d": {
-    "enabled": false,
-    "model_path": "ui/live2d_local/live2d_models/重音テト/重音テト.model3.json",
-    "fallback_image": "ui/img/standby.png",
-    "auto_switch": true,
-    "animation_enabled": true,
-    "touch_interaction": true
+    "api_base": "",
+    "api_key": ""
   },
   "system_check": {
     "passed": false,
     "timestamp": "",
     "python_version": "",
     "project_path": ""
-  },
-  "pypi": {
-    "token_name": "RTGS",
-    "api": "pypi-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
   }
 }

--- a/main.py
+++ b/main.py
@@ -89,7 +89,7 @@ if not hasattr(socket, 'EAI_ADDRFAMILY'):
 
 # 本地模块导入
 from system.system_checker import run_system_check, run_quick_check
-from system.config import config, AI_NAME
+from system.config import config, AI_NAME, get_config_path, sync_source_config_to_runtime
 
 # V14版本已移除早期拦截器，采用运行时猴子补丁
 
@@ -628,7 +628,7 @@ def check_and_update_if_needed() -> bool:
     from datetime import datetime
     import json5
 
-    config_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), "config.json")
+    config_file = get_config_path()
 
     if not os.path.exists(config_file):
         return False
@@ -694,6 +694,8 @@ def _lazy_init_services():
     """延迟初始化服务 - 在需要时才初始化"""
     global service_manager, n
     if not hasattr(_lazy_init_services, '_initialized'):
+        sync_source_config_to_runtime()
+
         # 初始化服务管理器
         service_manager = ServiceManager()
         service_manager.start_background_services()
@@ -777,6 +779,7 @@ if __name__ == "__main__":
         sys.exit(0 if success else 1)
 
     # 检查上次系统检测时间，如果超过7天则执行更新
+    sync_source_config_to_runtime()
     check_and_update_if_needed()
 
     # 启动前清理占用端口的进程

--- a/system/config.py
+++ b/system/config.py
@@ -8,6 +8,7 @@ import os
 import sys
 import json
 import re
+import shutil
 try:
     import tomllib
 except ModuleNotFoundError:
@@ -78,6 +79,32 @@ def get_config_path() -> str:
     target = d / "config.json"
     _migrate_config_if_needed(target)
     return str(target)
+
+
+def sync_source_config_to_runtime() -> bool:
+    """源码运行时将项目根目录 config.json 同步到用户数据目录。"""
+    if IS_PACKAGED:
+        return False
+
+    source = Path(__file__).parent.parent / "config.json"
+    if not source.exists():
+        return False
+
+    target = Path(get_data_dir()) / "config.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        source_bytes = source.read_bytes()
+        target_bytes = target.read_bytes() if target.exists() else None
+        if target_bytes == source_bytes:
+            return False
+
+        shutil.copy2(source, target)
+        print(f"已同步源码配置: {source} → {target}")
+        return True
+    except Exception as e:
+        print(f"警告：同步源码配置失败: {e}")
+        return False
 
 from pydantic import BaseModel, Field, field_validator
 from charset_normalizer import from_path

--- a/system/config.py
+++ b/system/config.py
@@ -8,7 +8,6 @@ import os
 import sys
 import json
 import re
-import shutil
 try:
     import tomllib
 except ModuleNotFoundError:
@@ -81,8 +80,66 @@ def get_config_path() -> str:
     return str(target)
 
 
+_RUNTIME_PROTECTED_CONFIG_PATHS = {
+    "system_check",
+}
+
+_MODEL_SYNC_CONFIG_PATHS = {
+    "api.model",
+    "api.api_format",
+    "voice_realtime.provider",
+    "voice_realtime.model",
+    "voice_realtime.tts_model",
+    "voice_realtime.asr_model",
+    "computer_control.model",
+    "computer_control.grounding_model",
+    "embedding.model",
+    "guide_engine.embedding_api_model",
+    "guide_engine.game_guide_llm_api_model",
+    "guide_engine.game_guide_llm_api_type",
+    "openclaw.default_model",
+}
+
+
+def _merge_source_config_into_runtime(source_value, target_value, path: str = ""):
+    if path in _RUNTIME_PROTECTED_CONFIG_PATHS:
+        return target_value, False
+
+    if path in _MODEL_SYNC_CONFIG_PATHS:
+        if target_value != source_value:
+            return source_value, True
+        return target_value, False
+
+    if isinstance(source_value, dict):
+        target_dict = target_value if isinstance(target_value, dict) else {}
+        merged = dict(target_dict)
+        changed = not isinstance(target_value, dict)
+
+        for key, source_child in source_value.items():
+            child_path = f"{path}.{key}" if path else key
+            if key in target_dict:
+                merged_child, child_changed = _merge_source_config_into_runtime(
+                    source_child,
+                    target_dict[key],
+                    child_path,
+                )
+                if child_changed:
+                    merged[key] = merged_child
+                    changed = True
+            else:
+                merged[key] = source_child
+                changed = True
+
+        return merged, changed
+
+    if target_value is None:
+        return source_value, True
+
+    return target_value, False
+
+
 def sync_source_config_to_runtime() -> bool:
-    """源码运行时将项目根目录 config.json 同步到用户数据目录。"""
+    """源码运行时同步配置结构到用户数据目录，同时强制刷新模型相关配置。"""
     if IS_PACKAGED:
         return False
 
@@ -94,13 +151,23 @@ def sync_source_config_to_runtime() -> bool:
     target.parent.mkdir(parents=True, exist_ok=True)
 
     try:
-        source_bytes = source.read_bytes()
-        target_bytes = target.read_bytes() if target.exists() else None
-        if target_bytes == source_bytes:
+        with open(source, "r", encoding=detect_file_encoding(str(source))) as source_file:
+            source_config = json5.load(source_file)
+
+        if target.exists():
+            with open(target, "r", encoding=detect_file_encoding(str(target))) as target_file:
+                target_config = json5.load(target_file)
+        else:
+            target_config = {}
+
+        merged_config, changed = _merge_source_config_into_runtime(source_config, target_config)
+        if not changed:
             return False
 
-        shutil.copy2(source, target)
-        print(f"已同步源码配置: {source} → {target}")
+        with open(target, "w", encoding="utf-8") as target_file:
+            json.dump(merged_config, target_file, ensure_ascii=False, indent=2)
+
+        print(f"已同步源码配置结构: {source} → {target}")
         return True
     except Exception as e:
         print(f"警告：同步源码配置失败: {e}")

--- a/system/config.py
+++ b/system/config.py
@@ -87,17 +87,6 @@ _RUNTIME_PROTECTED_CONFIG_PATHS = {
 _MODEL_SYNC_CONFIG_PATHS = {
     "api.model",
     "api.api_format",
-    "voice_realtime.provider",
-    "voice_realtime.model",
-    "voice_realtime.tts_model",
-    "voice_realtime.asr_model",
-    "computer_control.model",
-    "computer_control.grounding_model",
-    "embedding.model",
-    "guide_engine.embedding_api_model",
-    "guide_engine.game_guide_llm_api_model",
-    "guide_engine.game_guide_llm_api_type",
-    "openclaw.default_model",
 }
 
 
@@ -209,15 +198,26 @@ def _get_runtime_server_ports() -> Optional[ServerPortsConfig]:
         return None
 
     try:
-        raw_agent_port = server_ports.agent_server
-        raw_mcp_port = server_ports.mcp_server
+        raw_agent_port = getattr(getattr(loaded_config, "agent_server", None), "port", server_ports.agent_server)
+        raw_mcp_port = getattr(getattr(loaded_config, "mcp_server", None), "port", server_ports.mcp_server)
         try:
             config_path = get_config_path()
             if os.path.exists(config_path):
                 with open(config_path, "r", encoding=detect_file_encoding(config_path)) as f:
                     raw_config = json5.load(f)
-                raw_agent_port = int(raw_config.get("agentserver", {}).get("port", raw_agent_port))
-                raw_mcp_port = int(raw_config.get("mcpserver", {}).get("port", raw_mcp_port))
+
+                raw_agent_port = int(
+                    raw_config.get("agent_server", {}).get(
+                        "port",
+                        raw_config.get("agentserver", {}).get("port", raw_agent_port),
+                    )
+                )
+                raw_mcp_port = int(
+                    raw_config.get("mcp_server", {}).get(
+                        "port",
+                        raw_config.get("mcpserver", {}).get("port", raw_mcp_port),
+                    )
+                )
         except Exception:
             pass
 
@@ -397,6 +397,23 @@ class APIServerConfig(BaseModel):
     docs_enabled: bool = Field(default=True, description="是否启用API文档")
 
 
+class AgentServerConfig(BaseModel):
+    """Agent 服务器配置"""
+
+    enabled: bool = Field(default=True, description="是否启用 Agent 服务器")
+    host: str = Field(default="127.0.0.1", description="Agent 服务器主机")
+    port: int = Field(default_factory=lambda: server_ports.agent_server, description="Agent 服务器端口")
+
+
+class MCPServerConfig(BaseModel):
+    """MCP 服务器配置"""
+
+    enabled: bool = Field(default=True, description="是否启用 MCP 服务器")
+    host: str = Field(default="127.0.0.1", description="MCP 服务器主机")
+    port: int = Field(default_factory=lambda: server_ports.mcp_server, description="MCP 服务器端口")
+    agent_discovery: bool = Field(default=True, description="是否启用 Agent 自动发现")
+
+
 class GRAGConfig(BaseModel):
     """GRAG知识图谱记忆系统配置"""
 
@@ -539,6 +556,7 @@ class MemoryServerConfig(BaseModel):
 
     url: str = Field(default="http://localhost:8004", description="NagaMemory 服务地址")
     token: Optional[str] = Field(default=None, description="认证 Token（Bearer），留空则不携带认证头")
+    space_id: Optional[str] = Field(default=None, description="可选的记忆空间 ID")
 
 
 class EmbeddingConfig(BaseModel):
@@ -1302,6 +1320,8 @@ class NagaConfig(BaseModel):
     system: SystemConfig = Field(default_factory=SystemConfig)
     api: APIConfig = Field(default_factory=APIConfig)
     api_server: APIServerConfig = Field(default_factory=APIServerConfig)
+    agent_server: AgentServerConfig = Field(default_factory=AgentServerConfig)
+    mcp_server: MCPServerConfig = Field(default_factory=MCPServerConfig)
     grag: GRAGConfig = Field(default_factory=GRAGConfig)
     handoff: HandoffConfig = Field(default_factory=HandoffConfig)
     browser: BrowserConfig = Field(default_factory=BrowserConfig)

--- a/system/system_checker.py
+++ b/system/system_checker.py
@@ -25,12 +25,12 @@ class SystemChecker:
         self.project_root = Path(__file__).parent.parent  # 指向项目根目录
         self.venv_path = self.project_root / "venv"  # 更新为venv目录
         self.requirements_file = self.project_root / "requirements.txt"
-        self.config_file = self.project_root / "config.json"
         self.pyproject_file = self.project_root / "pyproject.toml"
         self.results = {}
 
         # 需要检测的端口 - 从config读取
-        from system.config import get_all_server_ports
+        from system.config import get_all_server_ports, get_config_path
+        self.config_file = Path(get_config_path())
         all_ports = get_all_server_ports()
         self.required_ports = [
             all_ports["api_server"],

--- a/voice/input/unified_voice_manager.py
+++ b/voice/input/unified_voice_manager.py
@@ -62,7 +62,11 @@ class UnifiedVoiceManager(QObject):
 
         # 检测本地FunASR
         try:
-            response = requests.get("http://localhost:5000/health", timeout=1)
+            from system.config import config
+            response = requests.get(
+                f"http://{config.voice_realtime.asr_host}:{config.asr.port}/health",
+                timeout=1,
+            )
             availability[VoiceMode.LOCAL] = response.status_code == 200
             logger.info(f"[统一语音] 本地FunASR服务: {'可用' if availability[VoiceMode.LOCAL] else '不可用'}")
         except:


### PR DESCRIPTION
总之， 之前前端/后端/启动阶段使用的配置不完全一致，加上`config.json.example`已经有点过时了。修复一堆旧代码+更新一堆过时接口，以及在源码编译时加入了动态覆盖用户目录的机制（非全量）等等

  ---
**详细变更**

  1.`system/config.py`- 配置路径与同步策略重构，统一用户数据目录， 所有运行时数据（配置、日志、会话等）统一收敛到：
  - Windows: %APPDATA%/NagaAgent
  - 其他: ~/.naga

  同步规则：
  - 运行时保护字段：`_RUNTIME_PROTECTED_CONFIG_PATHS`中的字段（如`system_check`）保留运行时值
  - 普通已有：字段优先保留，不覆盖
  - 缺失字段：自动补入
  - 模型字段：`_MODEL_SYNC_CONFIG_PATHS`中的字段强制同步

  ▎ *注：`_MODEL_SYNC_CONFIG_PATHS`可以根据情况手动更改，设为空`set()`或`{}`时即为无内容覆盖。*

  2.`main.py`- 启动流程接入配置同步，在主入口两处增加同步调用，确保首次运行时用户目录配置被正确初始化以及新增字段/主模型配置能及时从项目根同步

  3.`system/system_checker.py`- 检测改用运行时配置，检测器现在通过`get_config_path()`获取配置文件，而非假设位于项目根目录。

  4.`voice/input/unified_voice_manager.py`- 修正 ASR 健康检查端口
 
  5.`config.json.example`- 更新并且补齐示例配置