### PR TITLE
feat: 完善主动消息链路

### DIFF
--- a/apiserver/llm_service.py
+++ b/apiserver/llm_service.py
@@ -143,6 +143,18 @@ class LLMService:
             "api_base": (effective_base.rstrip("/") + "/" if effective_base else None),
         }
 
+    def _normalize_temperature(self, model_name: str, temperature: Optional[float]) -> Optional[float]:
+        """兼容不支持自定义 temperature 的模型参数约束。"""
+        if temperature is None:
+            return None
+
+        normalized_model = (model_name or "").lower()
+        if "gpt-5" in normalized_model and temperature != 1:
+            logger.info(f"[LLM] 模型 {model_name} 仅支持 temperature=1，自动调整当前值 {temperature}")
+            return 1
+
+        return temperature
+
     async def get_response(self, prompt: str, temperature: float = 0.7) -> str:
         """为其他模块提供API调用接口（保持向后兼容，只返回 content）"""
         response = await self.get_response_with_reasoning(prompt, temperature)
@@ -156,10 +168,11 @@ class LLMService:
                 return LLMResponse(content="LLM服务不可用: 客户端初始化失败")
 
         try:
+            model_name = self._get_model_name()
             response = await acompletion(
-                model=self._get_model_name(),
+                model=model_name,
                 messages=[{"role": "user", "content": prompt}],
-                temperature=temperature,
+                temperature=self._normalize_temperature(model_name, temperature),
                 max_tokens=get_config().api.max_tokens,
                 **self._get_llm_params()
             )
@@ -212,7 +225,7 @@ class LLMService:
             response = await acompletion(
                 model=model_name,
                 messages=messages,
-                temperature=temperature,
+                temperature=self._normalize_temperature(model_name, temperature),
                     max_tokens=get_config().api.max_tokens if hasattr(get_config().api, 'max_tokens') else None,
                 **self._get_overridden_llm_params(final_api_key, final_base)
             )
@@ -304,7 +317,7 @@ class LLMService:
                 call_params = {
                     "model": model_name,
                     "messages": messages,
-                    "temperature": temperature,
+                    "temperature": self._normalize_temperature(model_name, temperature),
                     "max_tokens": get_config().api.max_tokens if hasattr(get_config().api, "max_tokens") else None,
                     "stream": True,
                     "timeout": 120,

--- a/apiserver/routes/tools.py
+++ b/apiserver/routes/tools.py
@@ -12,6 +12,7 @@ from fastapi import APIRouter, HTTPException, WebSocket, WebSocketDisconnect
 from system.config import build_system_prompt, build_context_supplement
 from apiserver.message_manager import message_manager
 from apiserver.llm_service import get_llm_service
+from apiserver.websocket_manager import get_websocket_manager
 
 logger = logging.getLogger(__name__)
 
@@ -454,14 +455,26 @@ async def receive_proactive_message(payload: Dict[str, Any]):
         message = payload.get("message", "")
         source = payload.get("source", "ProactiveVision")
         timestamp = payload.get("timestamp", time.time())
+        session_id = payload.get("session_id")
 
         if not message:
             raise HTTPException(400, "message 不能为空")
 
         logger.info(f"[ProactiveMessage] 收到主动消息: {message[:50]}... (来源: {source})")
 
-        # 创建一个特殊的会话ID用于主动消息
-        proactive_session_id = f"proactive_{int(timestamp)}"
+        if not session_id:
+            recent_session_ids = [
+                sid for sid, session in message_manager.sessions.items()
+                if session.get("messages") and not session.get("temporary")
+            ]
+            if recent_session_ids:
+                recent_session_ids.sort(
+                    key=lambda sid: message_manager.sessions[sid].get("last_activity", ""),
+                    reverse=True,
+                )
+                session_id = recent_session_ids[0]
+            else:
+                session_id = message_manager.create_session()
 
         # 构建通知数据
         notification_data = {
@@ -469,24 +482,29 @@ async def receive_proactive_message(payload: Dict[str, Any]):
             "content": message,
             "source": source,
             "timestamp": timestamp,
-            "session_id": proactive_session_id,
+            "session_id": session_id,
         }
 
-        # TODO: 通过WebSocket或SSE推送到前端
-        # 目前暂存到消息管理器，前端可通过轮询获取
+        ws_manager = get_websocket_manager()
+
+        # 持久化到当前会话
+        message_manager.create_session(session_id)
         message_manager.add_message(
-            session_id=proactive_session_id,
+            session_id=session_id,
             role="assistant",
             content=f"[主动提醒 - {source}]\n{message}",
         )
 
-        logger.info(f"[ProactiveMessage] 主动消息已处理: {proactive_session_id}")
+        pushed = await ws_manager.send_proactive_message(message, source, session_id=session_id)
+
+        logger.info(f"[ProactiveMessage] 主动消息已处理: {session_id}, pushed={pushed}")
 
         return {
             "status": "ok",
             "message": "主动消息已接收",
-            "session_id": proactive_session_id,
+            "session_id": session_id,
             "data": notification_data,
+            "pushed": pushed,
         }
 
     except Exception as e:

--- a/apiserver/websocket_manager.py
+++ b/apiserver/websocket_manager.py
@@ -120,7 +120,7 @@ class WebSocketManager:
         logger.debug(f"[WebSocket] 广播完成: 发送{sent_count}条")
         return sent_count
 
-    async def send_proactive_message(self, message: str, source: str):
+    async def send_proactive_message(self, message: str, source: str, session_id: str = None):
         """发送主动消息（ProactiveVision专用）"""
         payload = {
             "type": "proactive_message",
@@ -128,6 +128,8 @@ class WebSocketManager:
             "source": source,
             "timestamp": asyncio.get_running_loop().time(),
         }
+        if session_id:
+            payload["session_id"] = session_id
 
         # 广播到所有连接
         sent_count = await self.broadcast(payload)

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -26,12 +26,13 @@ import { useElectron } from '@/composables/useElectron'
 import { useMusicPlayer } from '@/composables/useMusicPlayer'
 import { useParallax } from '@/composables/useParallax'
 import { useStartupProgress } from '@/composables/useStartupProgress'
+import { connectRealtimeUi, disconnectRealtimeUi } from '@/composables/useRealtimeUi'
 import { startToolPolling, stopToolPolling } from '@/composables/useToolStatus'
 import { checkForUpdate, showUpdateDialog, updateInfo } from '@/composables/useVersionCheck'
 import { backendConnected, CONFIG } from '@/utils/config'
 import { clearExpression, setExpression } from '@/utils/live2dController'
 import { destroyParallax, initParallax } from '@/utils/parallax'
-import { activeTabId, agentContacts, tabs } from '@/utils/session'
+import { activeTabId, agentContacts, proactiveNotifier, tabs } from '@/utils/session'
 import { messageViewExpanded } from '@/utils/uiState'
 import FloatingView from '@/views/FloatingView.vue'
 
@@ -346,6 +347,14 @@ function openLoginDialog() {
 
 // 提供给子组件使用
 provide('openLoginDialog', openLoginDialog)
+proactiveNotifier.value = (source, content) => {
+  toast.add({
+    severity: 'info',
+    summary: source,
+    detail: content,
+    life: 5000,
+  })
+}
 
 function onSplashDismiss() {
   _splashDismissed = true
@@ -452,10 +461,16 @@ watch(isNagaLoggedIn, (loggedIn) => {
 }, { immediate: true })
 
 watch(backendConnected, (connected) => {
-  if (connected && isNagaLoggedIn.value) {
-    startToolPolling()
+  if (connected) {
+    connectRealtimeUi()
+    if (isNagaLoggedIn.value) {
+      startToolPolling()
+    }
   }
-})
+  else {
+    disconnectRealtimeUi()
+  }
+}, { immediate: true })
 
 onMounted(() => {
   initParallax()
@@ -512,9 +527,11 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  proactiveNotifier.value = null
   destroyParallax()
   cleanup()
   stopToolPolling()
+  disconnectRealtimeUi()
   unsubStateChange?.()
 })
 </script>

--- a/frontend/src/api/core.ts
+++ b/frontend/src/api/core.ts
@@ -323,6 +323,15 @@ export class CoreApiClient extends ApiClient {
     return this.instance.get('/sessions')
   }
 
+  getProactiveMessageHistory(sessionId: string): Promise<{
+    status: string
+    sessionId: string
+    messages: Array<{ role: string, content: string }>
+    conversationRounds: number
+  }> {
+    return this.instance.get(`/sessions/${sessionId}`)
+  }
+
   getSessionDetail(id: string): Promise<{
     status: string
     sessionId: string

--- a/frontend/src/composables/useRealtimeUi.ts
+++ b/frontend/src/composables/useRealtimeUi.ts
@@ -1,0 +1,100 @@
+import { appendNagaMessage, CURRENT_SESSION_ID, proactiveNotifier, reloadCurrentSessionMessages } from '@/utils/session'
+
+let socket: WebSocket | null = null
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+let reconnectAttempts = 0
+let manuallyClosed = false
+
+function buildWebSocketUrl() {
+  const endpoint = import.meta.env.DEV ? 'http://localhost:8000' : window.location.origin
+  const url = new URL(endpoint)
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:'
+  url.pathname = '/ws'
+  url.search = ''
+  url.hash = ''
+  return url.toString()
+}
+
+function clearReconnectTimer() {
+  if (reconnectTimer) {
+    clearTimeout(reconnectTimer)
+    reconnectTimer = null
+  }
+}
+
+function scheduleReconnect() {
+  if (manuallyClosed || reconnectTimer)
+    return
+  const delay = Math.min(1000 * 2 ** reconnectAttempts, 10000)
+  reconnectAttempts += 1
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null
+    connectRealtimeUi()
+  }, delay)
+}
+
+async function handleMessage(event: MessageEvent<string>) {
+  try {
+    const payload = JSON.parse(event.data)
+    if (payload?.type !== 'proactive_message' || !payload.content)
+      return
+
+    const source = payload.source || 'ProactiveVision'
+    const sessionId = typeof payload.session_id === 'string' ? payload.session_id : ''
+
+    if (sessionId && !CURRENT_SESSION_ID.value)
+      CURRENT_SESSION_ID.value = sessionId
+
+    appendNagaMessage({
+      role: 'assistant',
+      content: payload.content,
+      sender: source,
+    })
+
+    proactiveNotifier.value?.(source, payload.content)
+
+    if (sessionId && CURRENT_SESSION_ID.value === sessionId) {
+      await reloadCurrentSessionMessages()
+    }
+  }
+  catch (error) {
+    console.debug('[RealtimeUI] 忽略无法解析的消息', error)
+  }
+}
+
+export function connectRealtimeUi() {
+  if (socket && (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING))
+    return
+
+  manuallyClosed = false
+  clearReconnectTimer()
+
+  const ws = new WebSocket(buildWebSocketUrl())
+  socket = ws
+
+  ws.addEventListener('open', () => {
+    reconnectAttempts = 0
+  })
+
+  ws.addEventListener('message', handleMessage)
+
+  ws.addEventListener('close', () => {
+    if (socket === ws)
+      socket = null
+    scheduleReconnect()
+  })
+
+  ws.addEventListener('error', () => {
+    ws.close()
+  })
+}
+
+export function disconnectRealtimeUi() {
+  manuallyClosed = true
+  clearReconnectTimer()
+  reconnectAttempts = 0
+  if (socket) {
+    socket.close()
+    socket = null
+  }
+}

--- a/frontend/src/utils/session.ts
+++ b/frontend/src/utils/session.ts
@@ -4,6 +4,8 @@ import { useStorage } from '@vueuse/core'
 import { ref } from 'vue'
 import API from '@/api/core'
 
+export const proactiveNotifier = ref<null | ((source: string, content: string) => void)>(null)
+
 export interface Message {
   role: 'system' | 'user' | 'assistant' | 'info'
   content: string
@@ -57,6 +59,19 @@ export function getActiveTab(): ChatTab {
 
 export function getNagaTab(): ChatTab {
   return tabs.value[0]!
+}
+
+export function appendNagaMessage(message: Message) {
+  MESSAGES.value.push(message)
+  syncNagaMessages()
+}
+
+export async function reloadCurrentSessionMessages() {
+  if (!CURRENT_SESSION_ID.value)
+    return
+  const detail = await API.getProactiveMessageHistory(CURRENT_SESSION_ID.value)
+  MESSAGES.value = normalizeMessages(detail.messages)
+  syncNagaMessages()
 }
 
 function normalizeToolEvent(input: any): ToolEvent | null {

--- a/vendor/openclaw/package-lock.json
+++ b/vendor/openclaw/package-lock.json
@@ -1136,14 +1136,6 @@
         "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
-    "node_modules/@discordjs/voice/node_modules/opusscript": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmmirror.com/opusscript/-/opusscript-0.0.8.tgz",
-      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@discordjs/voice/node_modules/prism-media": {
       "version": "1.3.5",
       "resolved": "https://registry.npmmirror.com/prism-media/-/prism-media-1.3.5.tgz",
@@ -3237,6 +3229,40 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@node-llama-cpp/linux-x64-cuda": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64-cuda/-/linux-x64-cuda-3.16.2.tgz",
+      "integrity": "sha512-LTBQFqjin7tyrLNJz0XWTB5QAHDsZV71/qiiRRjXdBKSZHVVaPLfdgxypGu7ggPeBNsv+MckRXdlH5C7yMtE4A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/linux-x64-cuda-ext": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/linux-x64-cuda-ext/-/linux-x64-cuda-ext-3.16.2.tgz",
+      "integrity": "sha512-47d9myCJauZyzAlN7IK1eIt/4CcBMslF+yHy4q+yJotD/RV/S6qRpK2kGn+ybtdVjkPGNCoPkHKcyla9iIVjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@node-llama-cpp/linux-x64-vulkan": {
       "version": "3.16.2",
       "resolved": "https://registry.npmmirror.com/@node-llama-cpp/linux-x64-vulkan/-/linux-x64-vulkan-3.16.2.tgz",
@@ -3311,6 +3337,57 @@
       "version": "3.16.2",
       "resolved": "https://registry.npmmirror.com/@node-llama-cpp/win-x64/-/win-x64-3.16.2.tgz",
       "integrity": "sha512-etrivzbyLNVhZlUosFW8JSL0OSiuKQf9qcI3dNdehD907sHquQbBJrG7lXcdL6IecvXySp3oAwCkM87VJ0b3Fg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-x64-cuda": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-cuda/-/win-x64-cuda-3.16.2.tgz",
+      "integrity": "sha512-jStDELHrU3rKQMOk5Hs5bWEazyjE2hzHwpNf6SblOpaGkajM/HJtxEZoL0mLHJx5qeXs4oOVkr7AzuLy0WPpNA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-x64-cuda-ext": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-cuda-ext/-/win-x64-cuda-ext-3.16.2.tgz",
+      "integrity": "sha512-sdv4Kzn9bOQWNBRvw6B/zcn8dQRfZhjIHv5AfDBIOfRlSCgjebFpBeYUoU4wZPpjr3ISwcqO5MEWsw+AbUdV3Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@node-llama-cpp/win-x64-vulkan": {
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/@node-llama-cpp/win-x64-vulkan/-/win-x64-vulkan-3.16.2.tgz",
+      "integrity": "sha512-9xuHFCOhCQjZgQSFrk79EuSKn9nGWt/SAq/3wujQSQLtgp8jGdtZgwcmuDUoemInf10en2dcOmEt7t8dQdC3XA==",
       "cpu": [
         "x64"
       ],


### PR DESCRIPTION
**总结**                                                 
    这次改动主要围绕两件事展开：一是把主动消息链路补完整，让消息既能实时到达前端，也能稳定留存在当前娜迦会话中；二是修复GPT-5系列模型在LiteLLM调用链路中的参数兼容问题，避免流式调用因为`temperature`设置报错。整体上优先复用了现有会话、`WebSocket`、`PrimeVue Toast`和前端共享消息状态，没有额外引入新的通知系统或存储逻辑。
                                                                                                                                                                                    
**大致更改内容**                                  
  - 打通主动消息的前后端实时链路，后端`POST /proactive_message`会通过`WebSocket`广播给前端，前端新增`realtime`接收与重连逻辑。
  - 修正开发环境下`WebSocket`连接地址，避免前端误连到`Vite`开发端口，确保实时消息能真正连接到后端`/ws`。                                                                             
  - 去掉`realtime WebSocket`对登录态的依赖，只要后端可用就建立连接，减少主动消息被登录流程阻断的情况。
  - 将主动消息从独立`proactive_*`会话改为写入当前娜迦正式会话，并在广播`payload`中补上`session_id`，让前端即时显示与后端持久化历史保持一致。
  - 前端收到主动消息后直接写入共享的Naga消息状态，保证主聊天和悬浮窗共用同一份消息源；在需要时再刷新当前会话历史，避免切出聊天后消息丢失。
  - 复用现有`PrimeVue Toast`体系，为主动消息增加与当前 UI 风格一致的轻量弹窗提醒。
  - 修复GPT-5系列在`LiteLLM`下不支持`temperature=0.7`的问题，在后端统一对GPT-5系列模型做`temperature`归一化处理，避免流式调用报错。
  - 补充并恢复前端会话相关API封装，支撑主动消息历史回读，同时避免影响原有会话列表与详情逻辑。

  **测试**

  *- 启动前后端后检查`/ws/stats`，确认存在活动`WebSocket`连接*
  *- 调用 POST /proactive_message，确认返回`pushed: true`* 
  *- 确认 POST /proactive_message 返回的是正式会话id，而不是旧的`proactive_*`*
  *- 调用 /sessions/{session_id}，确认主动消息已作为`assistant`消息写入当前会话*
  *- 在前端界面确认主动消息会同时出现在主聊天和悬浮窗*
  *- 在前端界面确认主动消息会触发`toast`提示*
  *- 在前端界面确认离开聊天后重新进入，主动消息仍保留在当前娜迦会话中*
