### PR TITLE
feat(frontend): 网关/本地模式配置 UI 与登录跳过 emit；Windows UTF-8 开发/日志修复

### DIFF
--- a/frontend/electron/modules/backend.ts
+++ b/frontend/electron/modules/backend.ts
@@ -135,7 +135,12 @@ export function startBackend(): void {
   appendBackendLog(`[Backend] Starting from ${cwd}`)
   appendBackendLog(`[Backend] Command: ${cmd} ${args.join(' ')}`)
 
-  const env: Record<string, string | undefined> = { ...process.env, PYTHONUNBUFFERED: '1' }
+  const env: Record<string, string | undefined> = {
+    ...process.env,
+    PYTHONUNBUFFERED: '1',
+    PYTHONIOENCODING: 'utf-8',
+    PYTHONUTF8: '1',
+  }
 
   const useDebugConsole = process.platform === 'win32' && shouldOpenDebugConsole()
 
@@ -200,14 +205,15 @@ export function startBackend(): void {
     detached: process.platform !== 'win32',
   })
 
-  backendProcess.stdout?.on('data', (data: Buffer) => {
-    const text = data.toString()
+  backendProcess.stdout?.setEncoding('utf-8')
+  backendProcess.stderr?.setEncoding('utf-8')
+
+  backendProcess.stdout?.on('data', (text: string) => {
     consumeStdoutChunk(text)
     console.log(`[Backend] ${text.trimEnd()}`)
   })
 
-  backendProcess.stderr?.on('data', (data: Buffer) => {
-    const text = data.toString()
+  backendProcess.stderr?.on('data', (text: string) => {
     console.error(`[Backend] ${text.trimEnd()}`)
     consumeStderrChunk(text)
   })

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "lint": "node scripts/run-eslint.mjs",
     "lint:fix": "node scripts/run-eslint.mjs --fix",
-    "dev": "vite",
+    "dev": "node scripts/dev.mjs",
     "dev:web": "npx cross-env WEB_ONLY=1 vite",
     "build": "node scripts/run-build.mjs",
     "preview": "vite preview",

--- a/frontend/scripts/dev.mjs
+++ b/frontend/scripts/dev.mjs
@@ -1,0 +1,16 @@
+import { execSync, spawn } from 'node:child_process'
+import process from 'node:process'
+
+if (process.platform === 'win32') {
+  try {
+    execSync('chcp 65001', { stdio: 'ignore' })
+  }
+  catch {}
+}
+
+const child = spawn('npx', ['vite'], {
+  stdio: 'inherit',
+  shell: true,
+})
+
+child.on('exit', code => process.exit(code ?? 0))

--- a/frontend/src/components/LoginDialog.vue
+++ b/frontend/src/components/LoginDialog.vue
@@ -213,7 +213,7 @@ function handleSkip() {
   trackTelemetry('login_skip', {
     mode: mode.value,
   })
-  window.open('https://github.com/RTGS2017/NagaAgent.git', '_blank')
+  emit('skip')
 }
 
 function openForgotPassword() {
@@ -314,7 +314,7 @@ const stopWatch = watch(backendConnected, (connected) => {
             <span class="login-link" @click="openForgotPassword">忘记密码</span>
           </div>
           <div class="login-skip" @click="handleSkip">
-            不登录，使用开源版本
+            不登录，直接进入
           </div>
         </template>
 
@@ -407,7 +407,7 @@ const stopWatch = watch(backendConnected, (connected) => {
             <span class="login-link" @click="openForgotPassword">忘记密码</span>
           </div>
           <div class="login-skip" @click="handleSkip">
-            不登录，使用开源版本
+            不登录，直接进入
           </div>
         </template>
       </div>

--- a/frontend/src/views/ConfigView.vue
+++ b/frontend/src/views/ConfigView.vue
@@ -235,6 +235,27 @@ async function testConnection() {
 
     <!-- 模型 Tab -->
     <div v-show="activeTab === 'model'">
+      <!-- 配置模式指示器 -->
+      <div class="config-mode-banner" :class="isNagaLoggedIn ? 'mode-gateway' : 'mode-local'">
+        <div class="config-mode-icon">
+          <span v-if="isNagaLoggedIn">&#9729;</span>
+          <span v-else>&#9881;</span>
+        </div>
+        <div class="config-mode-info">
+          <div class="config-mode-title">
+            {{ isNagaLoggedIn ? '网关模式' : '本地模式' }}
+          </div>
+          <div class="config-mode-desc">
+            <template v-if="isNagaLoggedIn">
+              已登录 <strong>{{ nagaUser?.username }}</strong>，所有模型请求通过 NagaModel 网关转发，无需配置 API 密钥
+            </template>
+            <template v-else>
+              未登录，需手动配置各模型的 API 地址和密钥
+            </template>
+          </div>
+        </div>
+      </div>
+
       <Accordion :value="accordionModel" class="pb-8" multiple>
         <!-- 大语言模型 -->
         <ConfigGroup value="llm" header="大语言模型">
@@ -254,14 +275,21 @@ async function testConnection() {
                 </span>
               </div>
             </ConfigItem>
-            <ConfigItem name="API 地址" description="大语言模型的 API 地址">
-              <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆 ({{ nagaUser?.username }})，使用 NagaModel 网关</span>
-              <InputText v-else v-model="CONFIG.api.base_url" />
-            </ConfigItem>
-            <ConfigItem name="API 密钥" description="大语言模型的 API 密钥">
-              <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆 ({{ nagaUser?.username }})，无需输入</span>
-              <InputText v-else v-model="CONFIG.api.api_key" type="password" />
-            </ConfigItem>
+            <!-- 网关模式: 合并显示连接状态 -->
+            <template v-if="isNagaLoggedIn">
+              <ConfigItem name="连接状态" description="API 地址与密钥由网关自动管理">
+                <span class="naga-authed">&#10003; NagaModel 网关已连接</span>
+              </ConfigItem>
+            </template>
+            <!-- 本地模式: 展开完整配置 -->
+            <template v-else>
+              <ConfigItem name="API 地址" description="兼容 OpenAI 格式的 API 地址">
+                <InputText v-model="CONFIG.api.base_url" placeholder="https://api.deepseek.com/v1" />
+              </ConfigItem>
+              <ConfigItem name="API 密钥" description="大语言模型的 API 密钥">
+                <InputText v-model="CONFIG.api.api_key" type="password" placeholder="sk-..." />
+              </ConfigItem>
+            </template>
             <Divider class="m-1!" />
             <ConfigItem name="最大令牌数" description="单次对话的最大长度限制">
               <InputNumber v-model="CONFIG.api.max_tokens" show-buttons />
@@ -287,31 +315,32 @@ async function testConnection() {
             </div>
           </template>
           <div class="grid gap-4">
-            <ConfigItem name="控制模型" description="用于电脑控制任务的主要模型">
-              <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，无需填写</span>
-              <InputText v-else v-model="CONFIG.computer_control.model" />
-            </ConfigItem>
-            <ConfigItem name="控制模型 API 地址" description="控制模型的 API 地址">
-              <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，使用 NagaModel 网关</span>
-              <InputText v-else v-model="CONFIG.computer_control.model_url" />
-            </ConfigItem>
-            <ConfigItem name="控制模型 API 密钥" description="控制模型的 API 密钥">
-              <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，无需输入</span>
-              <InputText v-else v-model="CONFIG.computer_control.api_key" />
-            </ConfigItem>
-            <Divider class="m-1!" />
-            <ConfigItem name="定位模型" description="用于元素定位和坐标识别的模型">
-              <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，无需填写</span>
-              <InputText v-else v-model="CONFIG.computer_control.grounding_model" />
-            </ConfigItem>
-            <ConfigItem name="定位模型 API 地址" description="定位模型的 API 地址">
-              <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，使用 NagaModel 网关</span>
-              <InputText v-else v-model="CONFIG.computer_control.grounding_url" />
-            </ConfigItem>
-            <ConfigItem name="定位模型 API 密钥" description="定位模型的 API 密钥">
-              <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，无需输入</span>
-              <InputText v-else v-model="CONFIG.computer_control.grounding_api_key" />
-            </ConfigItem>
+            <template v-if="isNagaLoggedIn">
+              <ConfigItem name="连接状态" description="控制模型与定位模型均由网关管理">
+                <span class="naga-authed">&#10003; NagaModel 网关已连接</span>
+              </ConfigItem>
+            </template>
+            <template v-else>
+              <ConfigItem name="控制模型" description="用于电脑控制任务的主要模型">
+                <InputText v-model="CONFIG.computer_control.model" />
+              </ConfigItem>
+              <ConfigItem name="控制模型 API 地址" description="控制模型的 API 地址">
+                <InputText v-model="CONFIG.computer_control.model_url" placeholder="https://..." />
+              </ConfigItem>
+              <ConfigItem name="控制模型 API 密钥" description="控制模型的 API 密钥">
+                <InputText v-model="CONFIG.computer_control.api_key" type="password" placeholder="sk-..." />
+              </ConfigItem>
+              <Divider class="m-1!" />
+              <ConfigItem name="定位模型" description="用于元素定位和坐标识别的模型">
+                <InputText v-model="CONFIG.computer_control.grounding_model" />
+              </ConfigItem>
+              <ConfigItem name="定位模型 API 地址" description="定位模型的 API 地址">
+                <InputText v-model="CONFIG.computer_control.grounding_url" placeholder="https://..." />
+              </ConfigItem>
+              <ConfigItem name="定位模型 API 密钥" description="定位模型的 API 密钥">
+                <InputText v-model="CONFIG.computer_control.grounding_api_key" type="password" placeholder="sk-..." />
+              </ConfigItem>
+            </template>
           </div>
         </ConfigGroup>
 
@@ -327,11 +356,15 @@ async function testConnection() {
             </div>
           </template>
           <div class="grid gap-4">
-            <ConfigItem name="模型名称" description="用于语音识别的模型">
-              <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，无需填写</span>
-              <InputText v-else v-model="CONFIG.voice_realtime.asr_model" />
-            </ConfigItem>
-            <template v-if="!isNagaLoggedIn">
+            <template v-if="isNagaLoggedIn">
+              <ConfigItem name="连接状态" description="语音识别由网关管理">
+                <span class="naga-authed">&#10003; NagaModel 网关已连接</span>
+              </ConfigItem>
+            </template>
+            <template v-else>
+              <ConfigItem name="模型名称" description="用于语音识别的模型">
+                <InputText v-model="CONFIG.voice_realtime.asr_model" />
+              </ConfigItem>
               <ConfigItem name="模型提供者" description="语音识别模型的提供者">
                 <Select v-model="CONFIG.voice_realtime.provider" :options="Object.keys(ASR_PROVIDERS)">
                   <template #option="{ option }">
@@ -343,12 +376,9 @@ async function testConnection() {
                 </Select>
               </ConfigItem>
               <ConfigItem name="API 密钥" description="语音识别模型的 API 密钥">
-                <InputText v-model="CONFIG.voice_realtime.api_key" />
+                <InputText v-model="CONFIG.voice_realtime.api_key" type="password" />
               </ConfigItem>
             </template>
-            <ConfigItem v-else name="API 密钥">
-              <span class="naga-authed">&#10003; 已登陆，无需输入</span>
-            </ConfigItem>
           </div>
         </ConfigGroup>
 
@@ -364,10 +394,6 @@ async function testConnection() {
             </div>
           </template>
           <div class="grid gap-4">
-            <ConfigItem name="模型名称" description="用于语音合成的模型">
-              <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，无需填写</span>
-              <InputText v-else v-model="CONFIG.voice_realtime.tts_model" />
-            </ConfigItem>
             <ConfigItem name="声线" description="语音合成模型的声线">
               <Select v-model="CONFIG.tts.default_voice" :options="Object.keys(TTS_VOICES)">
                 <template #option="{ option }">
@@ -378,35 +404,44 @@ async function testConnection() {
                 </template>
               </Select>
             </ConfigItem>
-            <template v-if="!isNagaLoggedIn">
+            <template v-if="isNagaLoggedIn">
+              <ConfigItem name="连接状态" description="语音合成由网关管理">
+                <span class="naga-authed">&#10003; NagaModel 网关已连接</span>
+              </ConfigItem>
+            </template>
+            <template v-else>
+              <ConfigItem name="模型名称" description="用于语音合成的模型">
+                <InputText v-model="CONFIG.voice_realtime.tts_model" />
+              </ConfigItem>
               <ConfigItem name="服务端口" description="用于语音合成的本地服务端口">
                 <InputNumber v-model="CONFIG.tts.port" :min="1000" :max="65535" show-buttons />
               </ConfigItem>
               <ConfigItem name="API 密钥" description="语音合成模型的 API 密钥">
-                <InputText v-model="CONFIG.tts.api_key" />
+                <InputText v-model="CONFIG.tts.api_key" type="password" />
               </ConfigItem>
             </template>
-            <ConfigItem v-else name="API 密钥">
-              <span class="naga-authed">&#10003; 已登陆，无需输入</span>
-            </ConfigItem>
           </div>
         </ConfigGroup>
 
         <!-- 嵌入模型 -->
         <ConfigGroup value="embedding" header="嵌入模型">
           <div class="grid gap-4">
-            <ConfigItem name="模型名称" description="用于向量嵌入的模型">
-              <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，无需填写</span>
-              <InputText v-else v-model="CONFIG.embedding.model" />
-            </ConfigItem>
-            <ConfigItem name="API 地址" description="嵌入模型的 API 地址（留空使用主模型地址）">
-              <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，使用 NagaModel 网关</span>
-              <InputText v-else v-model="CONFIG.embedding.api_base" />
-            </ConfigItem>
-            <ConfigItem name="API 密钥" description="嵌入模型的 API 密钥（留空使用主模型密钥）">
-              <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，无需输入</span>
-              <InputText v-else v-model="CONFIG.embedding.api_key" type="password" />
-            </ConfigItem>
+            <template v-if="isNagaLoggedIn">
+              <ConfigItem name="连接状态" description="嵌入模型由网关管理">
+                <span class="naga-authed">&#10003; NagaModel 网关已连接</span>
+              </ConfigItem>
+            </template>
+            <template v-else>
+              <ConfigItem name="模型名称" description="用于向量嵌入的模型">
+                <InputText v-model="CONFIG.embedding.model" />
+              </ConfigItem>
+              <ConfigItem name="API 地址" description="嵌入模型的 API 地址（留空使用主模型地址）">
+                <InputText v-model="CONFIG.embedding.api_base" placeholder="留空使用主模型地址" />
+              </ConfigItem>
+              <ConfigItem name="API 密钥" description="嵌入模型的 API 密钥（留空使用主模型密钥）">
+                <InputText v-model="CONFIG.embedding.api_key" type="password" placeholder="留空使用主模型密钥" />
+              </ConfigItem>
+            </template>
           </div>
         </ConfigGroup>
       </Accordion>
@@ -414,27 +449,34 @@ async function testConnection() {
 
     <!-- 记忆 Tab -->
     <div v-show="activeTab === 'memory'">
+      <!-- 配置模式指示器 -->
+      <div class="config-mode-banner" :class="isCloudMode ? 'mode-gateway' : 'mode-local'">
+        <div class="config-mode-icon">
+          <span v-if="isCloudMode">&#9729;</span>
+          <span v-else>&#9881;</span>
+        </div>
+        <div class="config-mode-info">
+          <div class="config-mode-title">
+            {{ isCloudMode ? '云端记忆' : '本地记忆' }}
+          </div>
+          <div class="config-mode-desc">
+            <template v-if="isCloudMode">
+              使用夏园云端记忆微服务，数据自动同步
+            </template>
+            <template v-else>
+              使用本地 Neo4j 图数据库存储记忆
+            </template>
+          </div>
+        </div>
+      </div>
+
       <Accordion :value="accordionMemory" class="pb-8" multiple>
-        <ConfigGroup value="neo4j">
-          <template #header>
-            <div class="w-full flex justify-between items-center -my-1.5">
-              <span>{{ isCloudMode ? '云端记忆服务' : 'Neo4j 数据库' }}</span>
-              <span v-if="isCloudMode" class="text-xs text-green-400 flex items-center gap-1">
-                <span class="inline-block w-2 h-2 rounded-full bg-green-400" />
-                已登录
-              </span>
-            </div>
-          </template>
+        <ConfigGroup value="neo4j" :header="isCloudMode ? '云端记忆服务' : 'Neo4j 数据库'">
           <div class="grid gap-4">
             <!-- 云端模式 -->
             <template v-if="isCloudMode">
               <ConfigItem name="服务状态" description="夏园 云端记忆微服务">
-                <div class="text-xs text-white/70">
-                  <div>用户: {{ nagaUser?.username }}</div>
-                  <div class="mt-1 text-white/40">
-                    云端记忆服务已连接
-                  </div>
-                </div>
+                <span class="naga-authed">&#10003; 云端记忆已连接 ({{ nagaUser?.username }})</span>
               </ConfigItem>
               <ConfigItem
                 v-if="memoryStats"
@@ -453,7 +495,7 @@ async function testConnection() {
                 <InputText v-model="CONFIG.grag.neo4j_user" placeholder="neo4j" />
               </ConfigItem>
               <ConfigItem name="密码" description="Neo4j 数据库密码">
-                <InputText v-model="CONFIG.grag.neo4j_password" placeholder="••••••••" />
+                <InputText v-model="CONFIG.grag.neo4j_password" type="password" placeholder="••••••••" />
               </ConfigItem>
             </template>
             <Divider class="m-1!" />
@@ -688,6 +730,55 @@ async function testConnection() {
   background: rgba(255, 255, 255, 0.1);
   border-color: rgba(255, 255, 255, 0.25);
   color: rgba(255, 255, 255, 0.9);
+}
+
+.config-mode-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid;
+}
+
+.config-mode-banner.mode-gateway {
+  background: rgba(74, 222, 128, 0.06);
+  border-color: rgba(74, 222, 128, 0.2);
+}
+
+.config-mode-banner.mode-local {
+  background: rgba(251, 191, 36, 0.06);
+  border-color: rgba(251, 191, 36, 0.2);
+}
+
+.config-mode-icon {
+  font-size: 1.25rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.mode-gateway .config-mode-icon { color: #4ade80; }
+.mode-local .config-mode-icon { color: #fbbf24; }
+
+.config-mode-title {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.mode-gateway .config-mode-title { color: #4ade80; }
+.mode-local .config-mode-title { color: #fbbf24; }
+
+.config-mode-desc {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.5);
+  line-height: 1.4;
+  margin-top: 0.125rem;
+}
+
+.config-mode-desc strong {
+  color: rgba(255, 255, 255, 0.8);
 }
 
 .naga-authed {

--- a/frontend/src/views/MemoryView.vue
+++ b/frontend/src/views/MemoryView.vue
@@ -73,22 +73,47 @@ onMounted(() => {
 
 <template>
   <BoxContainer class="text-sm">
+    <!-- 配置模式指示器 -->
+    <div class="config-mode-banner" :class="isNagaLoggedIn ? 'mode-gateway' : 'mode-local'">
+      <div class="config-mode-icon">
+        <span v-if="isNagaLoggedIn">&#9729;</span>
+        <span v-else>&#9881;</span>
+      </div>
+      <div class="config-mode-info">
+        <div class="config-mode-title">
+          {{ isNagaLoggedIn ? '网关模式' : '本地模式' }}
+        </div>
+        <div class="config-mode-desc">
+          <template v-if="isNagaLoggedIn">
+            已登录 <strong>{{ nagaUser?.username }}</strong>，所有模型请求通过 NagaModel 网关转发
+          </template>
+          <template v-else>
+            未登录，需手动配置各模型的 API 地址和密钥
+          </template>
+        </div>
+      </div>
+    </div>
+
     <Accordion :value="accordionValue" class="pb-8" multiple>
       <!-- 大语言模型 -->
       <ConfigGroup value="llm" header="大语言模型">
         <div class="grid gap-4">
           <ConfigItem name="模型名称" description="用于对话的大语言模型">
-            <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，无需填写</span>
-            <InputText v-else v-model="CONFIG.api.model" />
+            <InputText v-model="CONFIG.api.model" />
           </ConfigItem>
-          <ConfigItem name="API 地址" description="大语言模型的 API 地址">
-            <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆 ({{ nagaUser?.username }})，使用 NagaModel 网关</span>
-            <InputText v-else v-model="CONFIG.api.base_url" />
-          </ConfigItem>
-          <ConfigItem name="API 密钥" description="大语言模型的 API 密钥">
-            <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆 ({{ nagaUser?.username }})，无需输入</span>
-            <InputText v-else v-model="CONFIG.api.api_key" type="password" />
-          </ConfigItem>
+          <template v-if="isNagaLoggedIn">
+            <ConfigItem name="连接状态" description="API 地址与密钥由网关自动管理">
+              <span class="naga-authed">&#10003; NagaModel 网关已连接</span>
+            </ConfigItem>
+          </template>
+          <template v-else>
+            <ConfigItem name="API 地址" description="兼容 OpenAI 格式的 API 地址">
+              <InputText v-model="CONFIG.api.base_url" placeholder="https://api.deepseek.com/v1" />
+            </ConfigItem>
+            <ConfigItem name="API 密钥" description="大语言模型的 API 密钥">
+              <InputText v-model="CONFIG.api.api_key" type="password" placeholder="sk-..." />
+            </ConfigItem>
+          </template>
           <Divider class="m-1!" />
           <ConfigItem name="最大令牌数" description="单次对话的最大长度限制">
             <InputNumber v-model="CONFIG.api.max_tokens" show-buttons />
@@ -102,27 +127,12 @@ onMounted(() => {
         </div>
       </ConfigGroup>
 
-      <!-- 云端记忆服务 / Neo4j（含知识图谱选项） -->
-      <ConfigGroup value="neo4j">
-        <template #header>
-          <div class="w-full flex justify-between items-center -my-1.5">
-            <span>{{ isCloudMode ? '云端记忆服务' : 'Neo4j 数据库' }}</span>
-            <span v-if="isCloudMode" class="text-xs text-green-400 flex items-center gap-1">
-              <span class="inline-block w-2 h-2 rounded-full bg-green-400" />
-              已登录
-            </span>
-          </div>
-        </template>
+      <!-- 云端记忆服务 / Neo4j -->
+      <ConfigGroup value="neo4j" :header="isCloudMode ? '云端记忆服务' : 'Neo4j 数据库'">
         <div class="grid gap-4">
-          <!-- 云端模式：显示连接状态 -->
           <template v-if="isCloudMode">
             <ConfigItem name="服务状态" description="夏园 云端记忆微服务">
-              <div class="text-xs text-white/70">
-                <div>用户: {{ nagaUser?.username }}</div>
-                <div class="mt-1 text-white/40">
-                  云端记忆服务已连接
-                </div>
-              </div>
+              <span class="naga-authed">&#10003; 云端记忆已连接 ({{ nagaUser?.username }})</span>
             </ConfigItem>
             <ConfigItem
               v-if="memoryStats"
@@ -132,7 +142,6 @@ onMounted(() => {
               <span class="text-white/70">{{ memoryStats.totalQuintuples ?? 0 }}</span>
             </ConfigItem>
           </template>
-          <!-- 本地模式：显示 Neo4j 配置 -->
           <template v-else>
             <ConfigItem name="连接地址" description="Neo4j 数据库连接 URI">
               <InputText v-model="CONFIG.grag.neo4j_uri" placeholder="neo4j://127.0.0.1:7687" />
@@ -141,11 +150,10 @@ onMounted(() => {
               <InputText v-model="CONFIG.grag.neo4j_user" placeholder="neo4j" />
             </ConfigItem>
             <ConfigItem name="密码" description="Neo4j 数据库密码">
-              <InputText v-model="CONFIG.grag.neo4j_password" placeholder="••••••••" />
+              <InputText v-model="CONFIG.grag.neo4j_password" type="password" placeholder="••••••••" />
             </ConfigItem>
           </template>
           <Divider class="m-1!" />
-          <!-- 知识图谱选项（原独立分组，现合并至此） -->
           <ConfigItem name="知识图谱">
             <label class="flex items-center gap-4">
               启用
@@ -191,31 +199,32 @@ onMounted(() => {
           </div>
         </template>
         <div class="grid gap-4">
-          <ConfigItem name="控制模型" description="用于电脑控制任务的主要模型">
-            <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，无需填写</span>
-            <InputText v-else v-model="CONFIG.computer_control.model" />
-          </ConfigItem>
-          <ConfigItem name="控制模型 API 地址" description="控制模型的 API 地址">
-            <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，使用 NagaModel 网关</span>
-            <InputText v-else v-model="CONFIG.computer_control.model_url" />
-          </ConfigItem>
-          <ConfigItem name="控制模型 API 密钥" description="控制模型的 API 密钥">
-            <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，无需输入</span>
-            <InputText v-else v-model="CONFIG.computer_control.api_key" />
-          </ConfigItem>
-          <Divider class="m-1!" />
-          <ConfigItem name="定位模型" description="用于元素定位和坐标识别的模型">
-            <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，无需填写</span>
-            <InputText v-else v-model="CONFIG.computer_control.grounding_model" />
-          </ConfigItem>
-          <ConfigItem name="定位模型 API 地址" description="定位模型的 API 地址">
-            <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，使用 NagaModel 网关</span>
-            <InputText v-else v-model="CONFIG.computer_control.grounding_url" />
-          </ConfigItem>
-          <ConfigItem name="定位模型 API 密钥" description="定位模型的 API 密钥">
-            <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，无需输入</span>
-            <InputText v-else v-model="CONFIG.computer_control.grounding_api_key" />
-          </ConfigItem>
+          <template v-if="isNagaLoggedIn">
+            <ConfigItem name="连接状态" description="控制模型与定位模型均由网关管理">
+              <span class="naga-authed">&#10003; NagaModel 网关已连接</span>
+            </ConfigItem>
+          </template>
+          <template v-else>
+            <ConfigItem name="控制模型" description="用于电脑控制任务的主要模型">
+              <InputText v-model="CONFIG.computer_control.model" />
+            </ConfigItem>
+            <ConfigItem name="控制模型 API 地址" description="控制模型的 API 地址">
+              <InputText v-model="CONFIG.computer_control.model_url" placeholder="https://..." />
+            </ConfigItem>
+            <ConfigItem name="控制模型 API 密钥" description="控制模型的 API 密钥">
+              <InputText v-model="CONFIG.computer_control.api_key" type="password" placeholder="sk-..." />
+            </ConfigItem>
+            <Divider class="m-1!" />
+            <ConfigItem name="定位模型" description="用于元素定位和坐标识别的模型">
+              <InputText v-model="CONFIG.computer_control.grounding_model" />
+            </ConfigItem>
+            <ConfigItem name="定位模型 API 地址" description="定位模型的 API 地址">
+              <InputText v-model="CONFIG.computer_control.grounding_url" placeholder="https://..." />
+            </ConfigItem>
+            <ConfigItem name="定位模型 API 密钥" description="定位模型的 API 密钥">
+              <InputText v-model="CONFIG.computer_control.grounding_api_key" type="password" placeholder="sk-..." />
+            </ConfigItem>
+          </template>
         </div>
       </ConfigGroup>
 
@@ -231,11 +240,15 @@ onMounted(() => {
           </div>
         </template>
         <div class="grid gap-4">
-          <ConfigItem name="模型名称" description="用于语音识别的模型">
-            <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，无需填写</span>
-            <InputText v-else v-model="CONFIG.voice_realtime.asr_model" />
-          </ConfigItem>
-          <template v-if="!isNagaLoggedIn">
+          <template v-if="isNagaLoggedIn">
+            <ConfigItem name="连接状态" description="语音识别由网关管理">
+              <span class="naga-authed">&#10003; NagaModel 网关已连接</span>
+            </ConfigItem>
+          </template>
+          <template v-else>
+            <ConfigItem name="模型名称" description="用于语音识别的模型">
+              <InputText v-model="CONFIG.voice_realtime.asr_model" />
+            </ConfigItem>
             <ConfigItem name="模型提供者" description="语音识别模型的提供者">
               <Select v-model="CONFIG.voice_realtime.provider" :options="Object.keys(ASR_PROVIDERS)">
                 <template #option="{ option }">
@@ -247,12 +260,9 @@ onMounted(() => {
               </Select>
             </ConfigItem>
             <ConfigItem name="API 密钥" description="语音识别模型的 API 密钥">
-              <InputText v-model="CONFIG.voice_realtime.api_key" />
+              <InputText v-model="CONFIG.voice_realtime.api_key" type="password" />
             </ConfigItem>
           </template>
-          <ConfigItem v-else name="API 密钥">
-            <span class="naga-authed">&#10003; 已登陆，无需输入</span>
-          </ConfigItem>
         </div>
       </ConfigGroup>
 
@@ -268,10 +278,6 @@ onMounted(() => {
           </div>
         </template>
         <div class="grid gap-4">
-          <ConfigItem name="模型名称" description="用于语音合成的模型">
-            <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，无需填写</span>
-            <InputText v-else v-model="CONFIG.voice_realtime.tts_model" />
-          </ConfigItem>
           <ConfigItem name="声线" description="语音合成模型的声线">
             <Select v-model="CONFIG.tts.default_voice" :options="Object.keys(TTS_VOICES)">
               <template #option="{ option }">
@@ -282,35 +288,44 @@ onMounted(() => {
               </template>
             </Select>
           </ConfigItem>
-          <template v-if="!isNagaLoggedIn">
+          <template v-if="isNagaLoggedIn">
+            <ConfigItem name="连接状态" description="语音合成由网关管理">
+              <span class="naga-authed">&#10003; NagaModel 网关已连接</span>
+            </ConfigItem>
+          </template>
+          <template v-else>
+            <ConfigItem name="模型名称" description="用于语音合成的模型">
+              <InputText v-model="CONFIG.voice_realtime.tts_model" />
+            </ConfigItem>
             <ConfigItem name="服务端口" description="用于语音合成的本地服务端口">
               <InputNumber v-model="CONFIG.tts.port" :min="1000" :max="65535" show-buttons />
             </ConfigItem>
             <ConfigItem name="API 密钥" description="语音合成模型的 API 密钥">
-              <InputText v-model="CONFIG.tts.api_key" />
+              <InputText v-model="CONFIG.tts.api_key" type="password" />
             </ConfigItem>
           </template>
-          <ConfigItem v-else name="API 密钥">
-            <span class="naga-authed">&#10003; 已登陆，无需输入</span>
-          </ConfigItem>
         </div>
       </ConfigGroup>
 
       <!-- 嵌入模型 -->
       <ConfigGroup value="embedding" header="嵌入模型">
         <div class="grid gap-4">
-          <ConfigItem name="模型名称" description="用于向量嵌入的模型">
-            <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，无需填写</span>
-            <InputText v-else v-model="CONFIG.embedding.model" />
-          </ConfigItem>
-          <ConfigItem name="API 地址" description="嵌入模型的 API 地址（留空使用主模型地址）">
-            <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，使用 NagaModel 网关</span>
-            <InputText v-else v-model="CONFIG.embedding.api_base" />
-          </ConfigItem>
-          <ConfigItem name="API 密钥" description="嵌入模型的 API 密钥（留空使用主模型密钥）">
-            <span v-if="isNagaLoggedIn" class="naga-authed">&#10003; 已登陆，无需输入</span>
-            <InputText v-else v-model="CONFIG.embedding.api_key" type="password" />
-          </ConfigItem>
+          <template v-if="isNagaLoggedIn">
+            <ConfigItem name="连接状态" description="嵌入模型由网关管理">
+              <span class="naga-authed">&#10003; NagaModel 网关已连接</span>
+            </ConfigItem>
+          </template>
+          <template v-else>
+            <ConfigItem name="模型名称" description="用于向量嵌入的模型">
+              <InputText v-model="CONFIG.embedding.model" />
+            </ConfigItem>
+            <ConfigItem name="API 地址" description="嵌入模型的 API 地址（留空使用主模型地址）">
+              <InputText v-model="CONFIG.embedding.api_base" placeholder="留空使用主模型地址" />
+            </ConfigItem>
+            <ConfigItem name="API 密钥" description="嵌入模型的 API 密钥（留空使用主模型密钥）">
+              <InputText v-model="CONFIG.embedding.api_key" type="password" placeholder="留空使用主模型密钥" />
+            </ConfigItem>
+          </template>
         </div>
       </ConfigGroup>
     </Accordion>
@@ -318,6 +333,55 @@ onMounted(() => {
 </template>
 
 <style scoped>
+.config-mode-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  margin-bottom: 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid;
+}
+
+.config-mode-banner.mode-gateway {
+  background: rgba(74, 222, 128, 0.06);
+  border-color: rgba(74, 222, 128, 0.2);
+}
+
+.config-mode-banner.mode-local {
+  background: rgba(251, 191, 36, 0.06);
+  border-color: rgba(251, 191, 36, 0.2);
+}
+
+.config-mode-icon {
+  font-size: 1.25rem;
+  line-height: 1;
+  flex-shrink: 0;
+}
+
+.mode-gateway .config-mode-icon { color: #4ade80; }
+.mode-local .config-mode-icon { color: #fbbf24; }
+
+.config-mode-title {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.mode-gateway .config-mode-title { color: #4ade80; }
+.mode-local .config-mode-title { color: #fbbf24; }
+
+.config-mode-desc {
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.5);
+  line-height: 1.4;
+  margin-top: 0.125rem;
+}
+
+.config-mode-desc strong {
+  color: rgba(255, 255, 255, 0.8);
+}
+
 .naga-authed {
   color: #4ade80;
   font-size: 0.875rem;


### PR DESCRIPTION
## 摘要

修复构式的登录/本地选项，现在可以直接选择不登录使用了。优化模型配置显示。还有我们windows下跑前端会有的神秘锟斤拷语。

## 变更说明

**登录（`LoginDialog.vue`）**

- 「不登录」由打开 GitHub 仓库改为 `emit('skip')`，由上层决定行为。
- 文案由「不登录，使用开源版本」改为「不登录，直接进入」。

**配置与记忆（`ConfigView.vue`、`MemoryView.vue`）**

- 模型 Tab 顶部增加「网关模式 / 本地模式」说明横幅（含用户名等说明）。
- 已登录：各模块用统一的「连接状态 / NagaModel 网关已连接」替代多行「已登陆，无需填写」类提示。
- 未登录：保留完整 API 地址、密钥等表单项，增加 `placeholder`，敏感项使用 `type="password"`。
- `MemoryView`：LLM 在网关中仍显示模型名；Neo4j 分组标题简化为 prop；云端记忆状态展示收紧为一行；Neo4j 密码改为 password 输入。

**Electron 后端（`electron/modules/backend.ts`）**

- 子进程环境增加 `PYTHONIOENCODING=utf-8`、`PYTHONUTF8=1`。
- `stdout`/`stderr` 使用 UTF-8 编码读取，避免 Windows 下乱码。

**开发体验（`package.json` + 新文件 `scripts/dev.mjs`）**

- `dev` 脚本改为执行 `node scripts/dev.mjs`。
- 在 Windows 上先执行 `chcp 65001`，再 `spawn` `npx vite`，与终端代码页一致。

## 图
<img width="820" height="105" alt="屏幕截图 2026-04-25 200115" src="https://github.com/user-attachments/assets/9966106a-2716-4611-b562-904553b78d5d" />
<img width="824" height="99" alt="屏幕截图 2026-04-25 200100" src="https://github.com/user-attachments/assets/3e79489a-515a-4d9e-a2c6-3b5eadf73385" />
