### PR TITLE
feat: add custom Live2D model settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,23 +674,26 @@ NagaAgent/
 <details>
 <summary><b>Live2D 虚拟形象（自定义模型）</b></summary>
 
+在 **终端设置 → 音画配置 → Live2D 模型** 中可以直接上传自定义模型。请选择包含 `.model3.json`、`.moc3`、贴图、动作、物理文件等资源的完整模型目录，上传后会保存到用户数据目录并自动应用；也可以在 **枢机集市 → 角色注册 → 自定义角色** 中录入角色名、提示词并上传同一套 Live2D 模型目录。
+
 ```json
 {
   "web_live2d": {
     "ssaa": 2,
     "model": {
-      "source": "./models/your-model/model.model3.json",
+      "source": "由 GUI 或角色系统自动注入",
       "x": 0.5,
       "y": 1.3,
       "size": 6800
     },
+    "custom_model_id": "上传后自动生成的模型 ID",
     "face_y_ratio": 0.13,
     "tracking_hold_delay_ms": 100
   }
 }
 ```
 
-启用角色卡后，`ai_name` 与 `model.source` 由角色 JSON 自动覆盖，无需手动修改。
+启用角色卡后，`ai_name` 与 `model.source` 由角色 JSON 自动覆盖；使用自定义模型时，持久化的是 `custom_model_id`，`model.source` 会按当前 API 端口动态注入。
 </details>
 
 <details>

--- a/README_en.md
+++ b/README_en.md
@@ -670,23 +670,26 @@ Full-duplex realtime voice chat (requires Qwen DashScope API Key):
 <details>
 <summary><b>Live2D Avatar (Custom Model)</b></summary>
 
+Use **Terminal Settings → Audio/Visual Config → Live2D Model** to upload a custom model. Select the complete model directory that contains `.model3.json`, `.moc3`, textures, motions, physics files, and related assets. The uploaded model is stored under the user data directory and applied automatically. You can also use **Cardinal Market → Character Registration → Custom Character** to enter the character name, prompt, and the same Live2D model directory.
+
 ```json
 {
   "web_live2d": {
     "ssaa": 2,
     "model": {
-      "source": "./models/your-model/model.model3.json",
+      "source": "injected by the GUI or character system",
       "x": 0.5,
       "y": 1.3,
       "size": 6800
     },
+    "custom_model_id": "generated model ID after upload",
     "face_y_ratio": 0.13,
     "tracking_hold_delay_ms": 100
   }
 }
 ```
 
-When a character card is active, `ai_name` and `model.source` are automatically overridden by the character JSON — no manual edits needed.
+When a character card is active, `ai_name` and `model.source` are overridden by the character JSON. For custom models, `custom_model_id` is persisted and `model.source` is dynamically injected with the current API port.
 </details>
 
 <details>

--- a/README_ja.md
+++ b/README_ja.md
@@ -672,23 +672,26 @@ Neo4jなしの場合、GRAGはローカルJSONファイルストレージのみ�
 <details>
 <summary><b>Live2Dアバター（カスタムモデル）</b></summary>
 
+**端末設定 → 音声/ビジュアル設定 → Live2Dモデル** からカスタムモデルをアップロードできます。`.model3.json`、`.moc3`、テクスチャ、モーション、物理ファイルなどを含む完全なモデルディレクトリを選択してください。アップロード後はユーザーデータディレクトリに保存され、自動的に適用されます。**枢機集市 → キャラクター登録 → カスタムキャラクター** でも、キャラクター名、プロンプト、同じ Live2D モデルディレクトリを登録できます。
+
 ```json
 {
   "web_live2d": {
     "ssaa": 2,
     "model": {
-      "source": "./models/your-model/model.model3.json",
+      "source": "GUI またはキャラクターシステムが自動注入",
       "x": 0.5,
       "y": 1.3,
       "size": 6800
     },
+    "custom_model_id": "アップロード後に生成されるモデルID",
     "face_y_ratio": 0.13,
     "tracking_hold_delay_ms": 100
   }
 }
 ```
 
-キャラクターカードが有効な場合、`ai_name`と`model.source`はキャラクターJSONによって自動的に上書きされます — 手動編集は不要です。
+キャラクターカードが有効な場合、`ai_name` と `model.source` はキャラクター JSON によって上書きされます。カスタムモデルでは `custom_model_id` が永続化され、`model.source` は現在の API ポートに合わせて動的に注入されます。
 </details>
 
 <details>

--- a/apiserver/api_server.py
+++ b/apiserver/api_server.py
@@ -152,6 +152,7 @@ async def sync_auth_token(request: Request, call_next):
 # 挂载静态文件
 from fastapi.staticfiles import StaticFiles as _StaticFiles
 from system.config import CHARACTERS_DIR as _CHARACTERS_DIR
+from system.live2d_assets import CUSTOM_LIVE2D_DIR as _CUSTOM_LIVE2D_DIR
 if _CHARACTERS_DIR.exists():
     app.mount("/characters", _StaticFiles(directory=str(_CHARACTERS_DIR)), name="characters")
 else:
@@ -162,6 +163,12 @@ else:
         app.mount("/characters", _StaticFiles(directory=str(_CHARACTERS_DIR)), name="characters")
     except Exception as e:
         logger.error(f"角色静态目录初始化失败，将跳过 /characters 挂载: {e}")
+
+try:
+    _CUSTOM_LIVE2D_DIR.mkdir(parents=True, exist_ok=True)
+    app.mount("/custom-live2d", _StaticFiles(directory=str(_CUSTOM_LIVE2D_DIR)), name="custom-live2d")
+except Exception as e:
+    logger.error(f"自定义 Live2D 静态目录初始化失败，将跳过 /custom-live2d 挂载: {e}")
 
 # ============ 运行时状态检查（naga_control） ============
 

--- a/apiserver/routes/system.py
+++ b/apiserver/routes/system.py
@@ -3,12 +3,18 @@
 import asyncio
 import logging
 import traceback
-from typing import Dict, Any
+from typing import Dict, Any, List
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 
 from system.config import get_config, VERSION, build_system_prompt
 from system.config_manager import get_config_snapshot, update_config
+from system.live2d_assets import (
+    create_custom_live2d_model,
+    delete_custom_live2d_model,
+    get_custom_live2d_model,
+    list_custom_live2d_models,
+)
 from apiserver.message_manager import message_manager
 from apiserver.api_server import SystemInfoResponse
 from apiserver.telemetry import emit_telemetry
@@ -117,19 +123,33 @@ async def get_system_config():
     try:
         config_data = get_config_snapshot()
 
-        # 动态注入角色 Live2D 模型路径
+        # 动态注入角色 Live2D 模型路径；未启用角色时按 custom_model_id 注入自定义模型路径。
+        injected_model_source = False
         try:
-            from system.config import load_character, CHARACTERS_DIR
+            from system.config import load_character
             from urllib.parse import quote
             char_name = get_config().system.active_character
-            char_data = load_character(char_name)
-            port = get_config().api_server.port
-            encoded_name = quote(char_name, safe="")
-            encoded_model = quote(char_data["live2d_model"], safe="/")
-            model_url = f"http://localhost:{port}/characters/{encoded_name}/{encoded_model}"
-            config_data.setdefault("web_live2d", {}).setdefault("model", {})["source"] = model_url
+            if char_name:
+                char_data = load_character(char_name)
+                port = get_config().api_server.port
+                encoded_name = quote(char_name, safe="")
+                encoded_model = quote(char_data["live2d_model"], safe="/")
+                model_url = f"http://localhost:{port}/characters/{encoded_name}/{encoded_model}"
+                config_data.setdefault("web_live2d", {}).setdefault("model", {})["source"] = model_url
+                injected_model_source = True
         except Exception as char_err:
             logger.warning(f"角色模型路径注入失败: {char_err}")
+        if not injected_model_source:
+            web_live2d = config_data.setdefault("web_live2d", {})
+            model_block = web_live2d.setdefault("model", {})
+            custom_model_id = str(web_live2d.get("custom_model_id") or "").strip()
+            if custom_model_id:
+                try:
+                    custom_model = get_custom_live2d_model(custom_model_id, get_config().api_server.port)
+                    if custom_model:
+                        model_block["source"] = custom_model["source"]
+                except Exception as custom_err:
+                    logger.warning(f"自定义 Live2D 模型路径注入失败: {custom_err}")
 
         return {"status": "success", "config": config_data}
     except Exception as e:
@@ -144,11 +164,15 @@ async def update_system_config(payload: Dict[str, Any]):
     try:
         before_snapshot = get_config_snapshot()
         before_notification = _notification_telemetry_snapshot(before_snapshot)
-        # 过滤掉由角色系统动态注入的 model.source，避免将 localhost URL 持久化
+        # 过滤掉由角色/自定义资源系统动态注入的 model.source，避免将 localhost URL 持久化
         web_live2d = payload.get("web_live2d", {})
         model_block = web_live2d.get("model", {})
+        if isinstance(web_live2d, dict):
+            web_live2d.pop("custom_models", None)
         source = model_block.get("source", "")
-        if source and "/characters/" in source and source.startswith("http://localhost"):
+        if source and source.startswith("http://localhost") and (
+            "/characters/" in source or "/custom-live2d/" in source
+        ):
             model_block.pop("source", None)
 
         success = update_config(payload)
@@ -266,7 +290,7 @@ async def update_system_prompt(payload: Dict[str, Any]):
 async def get_active_character():
     """获取当前活跃角色信息及资源路径"""
     try:
-        from system.config import load_character, CHARACTERS_DIR
+        from system.config import load_character
         from urllib.parse import quote
         char_name = get_config().system.active_character
         char_data = load_character(char_name)
@@ -334,6 +358,59 @@ async def list_characters():
         logger.error(f"获取角色模板列表失败: {e}")
         traceback.print_exc()
         raise HTTPException(status_code=500, detail=f"获取角色模板列表失败: {str(e)}")
+
+
+@router.get("/system/live2d/custom-models")
+async def list_live2d_custom_models() -> Dict[str, Any]:
+    """列出用户上传的自定义 Live2D 模型。"""
+    try:
+        models = list_custom_live2d_models(get_config().api_server.port)
+        return {"status": "success", "models": models}
+    except Exception as e:
+        logger.error(f"获取自定义 Live2D 模型失败: {e}")
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail=f"获取自定义 Live2D 模型失败: {str(e)}")
+
+
+@router.post("/system/live2d/custom-models")
+async def upload_live2d_custom_model(
+    name: str = Form(...),
+    files: List[UploadFile] = File(...),
+    model_path: str = Form(""),
+) -> Dict[str, Any]:
+    """上传一整套 Live2D 模型资源并登记 .model3.json 入口。"""
+    try:
+        model = await create_custom_live2d_model(
+            name=name,
+            files=files,
+            requested_model_path=model_path or None,
+            api_port=get_config().api_server.port,
+        )
+        return {"status": "success", "model": model}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"上传自定义 Live2D 模型失败: {e}")
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail=f"上传自定义 Live2D 模型失败: {str(e)}")
+
+
+@router.delete("/system/live2d/custom-models/{model_id}")
+async def remove_live2d_custom_model(model_id: str) -> Dict[str, Any]:
+    """删除用户上传的自定义 Live2D 模型。"""
+    try:
+        deleted = delete_custom_live2d_model(model_id)
+        if not deleted:
+            raise HTTPException(status_code=404, detail="自定义 Live2D 模型不存在")
+        return {"status": "success", "message": "自定义 Live2D 模型已删除"}
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"删除自定义 Live2D 模型失败: {e}")
+        traceback.print_exc()
+        raise HTTPException(status_code=500, detail=f"删除自定义 Live2D 模型失败: {str(e)}")
 
 
 # ============ 更新检查 ============

--- a/config.json.example
+++ b/config.json.example
@@ -139,6 +139,18 @@
     "lip_sync_volume_scale": 1.5,
     "lip_sync_volume_threshold": 0.01
   },
+  "web_live2d": {
+    "ssaa": 2,
+    "model": {
+      "source": "./models/NagaTest2/NagaTest2.model3.json",
+      "x": 0.5,
+      "y": 1.3,
+      "size": 6800
+    },
+    "custom_model_id": null,
+    "face_y_ratio": 0.13,
+    "tracking_hold_delay_ms": 100
+  },
   "floating": {
     "enabled": false
   },

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -25,8 +25,8 @@ import { useBackground } from '@/composables/useBackground'
 import { useElectron } from '@/composables/useElectron'
 import { useMusicPlayer } from '@/composables/useMusicPlayer'
 import { useParallax } from '@/composables/useParallax'
-import { useStartupProgress } from '@/composables/useStartupProgress'
 import { connectRealtimeUi, disconnectRealtimeUi } from '@/composables/useRealtimeUi'
+import { useStartupProgress } from '@/composables/useStartupProgress'
 import { startToolPolling, stopToolPolling } from '@/composables/useToolStatus'
 import { checkForUpdate, showUpdateDialog, updateInfo } from '@/composables/useVersionCheck'
 import { backendConnected, CONFIG } from '@/utils/config'
@@ -421,7 +421,7 @@ watch(effectiveLive2dSource, (source) => {
   activeLive2dSource.value = source || DEFAULT_STARTUP_LIVE2D_SOURCE
 }, { immediate: true })
 
-watch([activeTabId, activeAgentCharacterTemplate, effectiveLive2dSource], () => {
+watch([activeTabId, activeAgentCharacterTemplate, effectiveLive2dSource, backendConnected], () => {
   live2dRenderKey.value += 1
 })
 

--- a/frontend/src/api/core.ts
+++ b/frontend/src/api/core.ts
@@ -65,6 +65,16 @@ export interface CharacterTemplate {
   active?: boolean
 }
 
+export interface CustomLive2DModel {
+  id: string
+  name: string
+  modelPath: string
+  source: string
+  fileCount: number
+  totalBytes: number
+  createdAt: string
+}
+
 export type AgentEngine = 'openclaw' | 'naga-core'
 
 export interface SkillCatalogItem {
@@ -255,6 +265,43 @@ export class CoreApiClient extends ApiClient {
     characters: CharacterTemplate[]
   }> {
     return this.instance.get('/system/characters')
+  }
+
+  listCustomLive2DModels(): Promise<{
+    status: 'success'
+    models: CustomLive2DModel[]
+  }> {
+    return this.instance.get('/system/live2d/custom-models')
+  }
+
+  uploadCustomLive2DModel(params: {
+    name: string
+    files: File[]
+    modelPath?: string
+  }): Promise<{
+    status: 'success'
+    model: CustomLive2DModel
+  }> {
+    const formData = new FormData()
+    formData.append('name', params.name)
+    if (params.modelPath) {
+      formData.append('model_path', params.modelPath)
+    }
+    for (const file of params.files) {
+      const relativePath = file.webkitRelativePath || file.name
+      formData.append('files', file, relativePath)
+    }
+    return this.instance.post('/system/live2d/custom-models', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+      timeout: 120000,
+    })
+  }
+
+  deleteCustomLive2DModel(id: string): Promise<{
+    status: 'success'
+    message: string
+  }> {
+    return this.instance.delete(`/system/live2d/custom-models/${encodeURIComponent(id)}`)
   }
 
   chat(message: string, options?: {

--- a/frontend/src/utils/config.ts
+++ b/frontend/src/utils/config.ts
@@ -9,6 +9,16 @@ export interface Model {
   size: number
 }
 
+export interface CustomLive2DModelConfig {
+  id: string
+  name: string
+  source: string
+  model_path: string
+  file_count: number
+  total_bytes: number
+  created_at: string
+}
+
 export function defineModel(model: Model) {
   return model
 }
@@ -260,6 +270,8 @@ export const DEFAULT_CONFIG = {
   web_live2d: {
     ssaa: 2,
     model: MODELS[DEFAULT_MODEL],
+    custom_models: [] as CustomLive2DModelConfig[],
+    custom_model_id: null as string | null,
     face_y_ratio: 0.13, // 视角追踪面部Y轴位置比例（0=模型顶部, 1=底部）
     tracking_hold_delay_ms: 100, // 按住超过该毫秒数后才开始视角追踪，0=点击即追踪
   },

--- a/frontend/src/utils/live2dModels.ts
+++ b/frontend/src/utils/live2dModels.ts
@@ -1,0 +1,49 @@
+import type { CustomLive2DModel } from '@/api/core'
+import type { CustomLive2DModelConfig, Model } from '@/utils/config'
+import { CONFIG } from '@/utils/config'
+
+export function toCustomLive2DModelConfig(model: CustomLive2DModel): CustomLive2DModelConfig {
+  return {
+    id: model.id,
+    name: model.name,
+    source: model.source,
+    model_path: model.modelPath,
+    file_count: model.fileCount,
+    total_bytes: model.totalBytes,
+    created_at: model.createdAt,
+  }
+}
+
+export function applyLive2DModel(model: Model): void {
+  CONFIG.value.web_live2d.model = {
+    source: model.source,
+    x: model.x,
+    y: model.y,
+    size: model.size,
+  }
+  CONFIG.value.web_live2d.custom_model_id = null
+}
+
+export function applyCustomLive2DModel(model: CustomLive2DModel | CustomLive2DModelConfig): void {
+  applyLive2DModel({
+    source: model.source,
+    x: CONFIG.value.web_live2d.model.x,
+    y: CONFIG.value.web_live2d.model.y,
+    size: CONFIG.value.web_live2d.model.size,
+  })
+  CONFIG.value.web_live2d.custom_model_id = model.id
+  CONFIG.value.system.active_character = ''
+}
+
+export function upsertCustomLive2DModel(model: CustomLive2DModel): CustomLive2DModelConfig {
+  const nextModel = toCustomLive2DModelConfig(model)
+  const models = CONFIG.value.web_live2d.custom_models
+  const index = models.findIndex(item => item.id === nextModel.id)
+  if (index >= 0) {
+    models[index] = nextModel
+  }
+  else {
+    models.unshift(nextModel)
+  }
+  return nextModel
+}

--- a/frontend/src/views/ConfigView.vue
+++ b/frontend/src/views/ConfigView.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { ModelPricing } from '@/api/business'
-import type { MemoryStats } from '@/api/core'
+import type { CustomLive2DModel, MemoryStats } from '@/api/core'
 import { useStorage } from '@vueuse/core'
 import { Accordion, Button, Divider, InputNumber, InputText, Message, Select, Slider, Textarea, ToggleSwitch } from 'primevue'
 import { useToast } from 'primevue/usetoast'
@@ -15,8 +15,9 @@ import NotificationSettingsPanel from '@/components/NotificationSettingsPanel.vu
 import { audioSettings, effectFileOptions, wakeVoiceOptions } from '@/composables/useAudio'
 import { isNagaLoggedIn, nagaUser } from '@/composables/useAuth'
 import { checkForUpdate } from '@/composables/useVersionCheck'
-import { CONFIG, DEFAULT_CONFIG, DEFAULT_MODEL, MODELS, SYSTEM_PROMPT } from '@/utils/config'
+import { backendConnected, CONFIG, DEFAULT_CONFIG, DEFAULT_MODEL, MODELS, SYSTEM_PROMPT } from '@/utils/config'
 import { trackingCalibration } from '@/utils/live2dController'
+import { applyCustomLive2DModel, applyLive2DModel, toCustomLive2DModelConfig, upsertCustomLive2DModel } from '@/utils/live2dModels'
 
 // ── Tab 切换 ──
 type TabKey = 'model' | 'memory' | 'terminal' | 'notifications'
@@ -38,16 +39,13 @@ const characterLockedHint = computed(() =>
     : undefined,
 )
 
-const selectedModel = ref(Object.entries(MODELS).find(([_, model]) => {
+const selectedModel = computed(() => Object.entries(MODELS).find(([_, model]) => {
   return model.source === CONFIG.value.web_live2d.model.source
 })?.[0] ?? DEFAULT_MODEL)
 
-const modelSelectRef = useTemplateRef<{
-  updateModel: (event: null, value: string) => void
-}>('modelSelectRef')
-
 function onModelChange(value: keyof typeof MODELS) {
-  CONFIG.value.web_live2d.model = { ...MODELS[value] }
+  applyLive2DModel({ ...MODELS[value] })
+  CONFIG.value.system.active_character = ''
 }
 
 const ssaaInputRef = useTemplateRef<{
@@ -57,7 +55,7 @@ const ssaaInputRef = useTemplateRef<{
 function recoverUiConfig() {
   if (!characterLocked.value) {
     CONFIG.value.system.ai_name = DEFAULT_CONFIG.system.ai_name
-    modelSelectRef.value?.updateModel(null, DEFAULT_MODEL)
+    onModelChange(DEFAULT_MODEL)
   }
   CONFIG.value.ui.user_name = DEFAULT_CONFIG.ui.user_name
   ssaaInputRef.value?.updateModel(null, DEFAULT_CONFIG.web_live2d.ssaa)
@@ -170,6 +168,112 @@ async function onAutoLaunchChange(value: boolean) {
 }
 
 const checkingUpdate = ref(false)
+const customLive2dModels = computed(() => CONFIG.value.web_live2d.custom_models)
+const customLive2dName = ref('')
+const customLive2dFiles = ref<File[]>([])
+const customLive2dModelPath = ref('')
+const customLive2dUploading = ref(false)
+const customLive2dLoading = ref(false)
+const customLive2dFileInputRef = ref<HTMLInputElement | null>(null)
+const customLive2dReady = computed(() =>
+  customLive2dName.value.trim() !== '' && customLive2dFiles.value.length > 0,
+)
+
+function formatFileSize(bytes: number) {
+  if (!Number.isFinite(bytes) || bytes <= 0)
+    return '0 KB'
+  if (bytes < 1024 * 1024)
+    return `${Math.max(1, Math.round(bytes / 1024))} KB`
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`
+}
+
+function getFileRelativePath(file: File) {
+  return file.webkitRelativePath || file.name
+}
+
+function pickCustomLive2dFolder() {
+  customLive2dFileInputRef.value?.click()
+}
+
+function handleCustomLive2dFilesChange(event: Event) {
+  const input = event.target as HTMLInputElement
+  const files = Array.from(input.files ?? [])
+  customLive2dFiles.value = files
+  const modelFiles = files
+    .map(getFileRelativePath)
+    .filter(path => path.toLowerCase().endsWith('.model3.json'))
+  customLive2dModelPath.value = modelFiles.length === 1 ? modelFiles[0] ?? '' : ''
+  if (!customLive2dName.value.trim() && customLive2dModelPath.value) {
+    const parts = customLive2dModelPath.value.split('/')
+    customLive2dName.value = parts.length > 1
+      ? parts[parts.length - 2] ?? ''
+      : parts[0]?.replace(/\.model3\.json$/i, '') ?? ''
+  }
+}
+
+async function loadCustomLive2dModels() {
+  if (!backendConnected.value || customLive2dLoading.value)
+    return
+  customLive2dLoading.value = true
+  try {
+    const res = await API.listCustomLive2DModels()
+    CONFIG.value.web_live2d.custom_models = (res.models || []).map(toCustomLive2DModelConfig)
+  }
+  catch {
+    // 后端旧版本或暂不可用时不影响其他设置
+  }
+  finally {
+    customLive2dLoading.value = false
+  }
+}
+
+watch(backendConnected, (connected) => {
+  if (connected) {
+    loadCustomLive2dModels()
+  }
+}, { immediate: true })
+
+async function uploadCustomLive2dModel() {
+  if (!customLive2dReady.value || customLive2dUploading.value)
+    return
+  customLive2dUploading.value = true
+  try {
+    const res = await API.uploadCustomLive2DModel({
+      name: customLive2dName.value.trim(),
+      files: customLive2dFiles.value,
+      modelPath: customLive2dModelPath.value || undefined,
+    })
+    const savedModel = upsertCustomLive2DModel(res.model)
+    applyCustomLive2DModel(savedModel)
+    customLive2dName.value = ''
+    customLive2dFiles.value = []
+    customLive2dModelPath.value = ''
+    if (customLive2dFileInputRef.value) {
+      customLive2dFileInputRef.value.value = ''
+    }
+    toast.add({ severity: 'success', summary: 'Live2D 已应用', detail: res.model.name, life: 2500 })
+  }
+  catch (e: any) {
+    toast.add({ severity: 'error', summary: '上传失败', detail: e?.response?.data?.detail || e.message, life: 4000 })
+  }
+  finally {
+    customLive2dUploading.value = false
+  }
+}
+
+async function deleteCustomLive2dModel(model: CustomLive2DModel | typeof CONFIG.value.web_live2d.custom_models[number]) {
+  try {
+    await API.deleteCustomLive2DModel(model.id)
+    CONFIG.value.web_live2d.custom_models = CONFIG.value.web_live2d.custom_models.filter(item => item.id !== model.id)
+    if (CONFIG.value.web_live2d.model.source === model.source) {
+      applyLive2DModel({ ...MODELS[DEFAULT_MODEL] })
+    }
+    toast.add({ severity: 'info', summary: '已删除', detail: model.name, life: 2200 })
+  }
+  catch (e: any) {
+    toast.add({ severity: 'error', summary: '删除失败', detail: e?.response?.data?.detail || e.message, life: 3000 })
+  }
+}
 
 async function handleCheckUpdate() {
   if (checkingUpdate.value)
@@ -575,6 +679,99 @@ async function testConnection() {
               <InputText v-model="CONFIG.ui.user_name" />
             </ConfigItem>
             <Divider class="m-1!" />
+            <ConfigItem layout="column" name="Live2D 模型" description="上传整套 Cubism 模型目录，或从已保存模型中切换">
+              <div class="live2d-model-panel">
+                <div class="builtin-live2d-row">
+                  <Select
+                    :options="Object.keys(MODELS)"
+                    :model-value="selectedModel"
+                    :disabled="characterLocked"
+                    @change="(event) => onModelChange(event.value)"
+                  />
+                  <Button
+                    size="small"
+                    label="角色注册"
+                    @click="configRouter.push('/market?tab=memory-skin')"
+                  />
+                </div>
+                <div v-if="characterLocked" class="live2d-lock-hint">
+                  {{ characterLockedHint }}
+                </div>
+
+                <div class="custom-live2d-uploader">
+                  <input
+                    ref="customLive2dFileInputRef"
+                    type="file"
+                    webkitdirectory
+                    directory
+                    multiple
+                    hidden
+                    @change="handleCustomLive2dFilesChange"
+                  >
+                  <InputText
+                    v-model="customLive2dName"
+                    class="min-w-0"
+                    placeholder="自定义模型名称"
+                  />
+                  <Button
+                    size="small"
+                    outlined
+                    :label="customLive2dFiles.length ? `${customLive2dFiles.length} 个文件` : '选择目录'"
+                    @click="pickCustomLive2dFolder"
+                  />
+                  <Button
+                    size="small"
+                    label="上传并应用"
+                    :disabled="!customLive2dReady"
+                    :loading="customLive2dUploading"
+                    @click="uploadCustomLive2dModel"
+                  />
+                </div>
+                <div v-if="customLive2dModelPath" class="live2d-path-hint">
+                  入口文件：{{ customLive2dModelPath }}
+                </div>
+
+                <div class="custom-live2d-list">
+                  <div v-if="customLive2dLoading" class="custom-live2d-empty">
+                    正在读取模型列表...
+                  </div>
+                  <div v-else-if="customLive2dModels.length === 0" class="custom-live2d-empty">
+                    暂无自定义 Live2D 模型
+                  </div>
+                  <template v-else>
+                    <div
+                      v-for="model in customLive2dModels"
+                      :key="model.id"
+                      class="custom-live2d-item"
+                      :class="{ active: CONFIG.web_live2d.model.source === model.source }"
+                    >
+                      <div class="custom-live2d-meta">
+                        <div class="custom-live2d-name">{{ model.name }}</div>
+                        <div class="custom-live2d-detail">
+                          {{ model.file_count }} 个文件 · {{ formatFileSize(model.total_bytes) }}
+                        </div>
+                      </div>
+                      <div class="custom-live2d-actions">
+                        <Button
+                          size="small"
+                          :label="CONFIG.web_live2d.model.source === model.source ? '使用中' : '应用'"
+                          :disabled="CONFIG.web_live2d.model.source === model.source"
+                          @click="applyCustomLive2DModel(model)"
+                        />
+                        <Button
+                          size="small"
+                          severity="danger"
+                          outlined
+                          label="删除"
+                          @click="deleteCustomLive2dModel(model)"
+                        />
+                      </div>
+                    </div>
+                  </template>
+                </div>
+              </div>
+            </ConfigItem>
+            <Divider class="m-1!" />
             <ConfigItem name="Live2D 模型位置">
               <div class="flex flex-col items-center justify-evenly">
                 <label v-for="direction in ['x', 'y'] as const" :key="direction" class="w-full flex items-center">
@@ -639,14 +836,10 @@ async function testConnection() {
             <ConfigItem name="角色名称" :description="characterLockedHint ?? '聊天窗口显示的 AI 昵称'">
               <InputText v-model="CONFIG.system.ai_name" :disabled="characterLocked" />
             </ConfigItem>
-            <ConfigItem name="L2D 模型" :description="characterLocked ? characterLockedHint : undefined">
-              <Select
-                ref="modelSelectRef"
-                :options="Object.keys(MODELS)"
-                :model-value="selectedModel"
-                :disabled="characterLocked"
-                @change="(event) => onModelChange(event.value)"
-              />
+            <ConfigItem name="L2D 模型" :description="characterLocked ? characterLockedHint : '在上方 Live2D 模型入口切换内置或自定义模型'">
+              <span class="live2d-source-preview">
+                {{ CONFIG.web_live2d.model.source }}
+              </span>
             </ConfigItem>
             <ConfigItem
               layout="column"
@@ -783,6 +976,75 @@ async function testConnection() {
   color: rgba(255, 255, 255, 0.4);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
+}
+
+.live2d-model-panel {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
+.builtin-live2d-row,
+.custom-live2d-uploader,
+.custom-live2d-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.custom-live2d-uploader {
+  flex-wrap: wrap;
+}
+
+.live2d-lock-hint,
+.live2d-path-hint,
+.custom-live2d-empty,
+.live2d-source-preview {
+  color: rgba(255, 255, 255, 0.48);
+  font-size: 12px;
+  line-height: 1.6;
+  overflow-wrap: anywhere;
+}
+
+.custom-live2d-list {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.custom-live2d-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-width: 0;
+  padding: 0.65rem 0.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.custom-live2d-item.active {
+  border-color: rgba(74, 222, 128, 0.42);
+  background: rgba(74, 222, 128, 0.08);
+}
+
+.custom-live2d-meta {
+  min-width: 0;
+}
+
+.custom-live2d-name {
+  color: rgba(255, 255, 255, 0.88);
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.custom-live2d-detail {
+  margin-top: 0.15rem;
+  color: rgba(255, 255, 255, 0.42);
+  font-size: 12px;
 }
 
 .terminal-footer {

--- a/frontend/src/views/MarketView.vue
+++ b/frontend/src/views/MarketView.vue
@@ -3,9 +3,11 @@ import { useToast } from 'primevue/usetoast'
 import { computed, h, nextTick, onMounted, reactive, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { getCredits, getPurchaseLink, redeemCode } from '@/api/business'
+import API from '@/api/core'
 import { isNagaLoggedIn, nagaUser, refreshUserStats, sessionRestored } from '@/composables/useAuth'
 import { useBackground } from '@/composables/useBackground'
-import { CONFIG } from '@/utils/config'
+import { CONFIG, SYSTEM_PROMPT } from '@/utils/config'
+import { applyCustomLive2DModel, upsertCustomLive2DModel } from '@/utils/live2dModels'
 
 const router = useRouter()
 const route = useRoute()
@@ -170,9 +172,15 @@ function applyCharacter(name: string) {
 }
 
 // ── 自定义角色 ──
-const customChar = reactive({ name: '', modelFile: null as File | null, prompt: '' })
+const customChar = reactive({
+  name: '',
+  modelFiles: [] as File[],
+  modelPath: '',
+  prompt: '',
+  uploading: false,
+})
 const customReady = computed(() =>
-  customChar.name.trim() !== '' && customChar.modelFile !== null && customChar.prompt.trim() !== '',
+  customChar.name.trim() !== '' && customChar.modelFiles.length > 0 && customChar.prompt.trim() !== '',
 )
 const fileInputRef = ref<HTMLInputElement | null>(null)
 
@@ -182,14 +190,38 @@ function triggerFileInput() {
 
 function onFileChange(e: Event) {
   const input = e.target as HTMLInputElement
-  if (input.files && input.files.length > 0) {
-    customChar.modelFile = input.files[0] ?? null
-  }
+  const files = Array.from(input.files ?? [])
+  customChar.modelFiles = files
+  const modelFiles = files
+    .map(file => file.webkitRelativePath || file.name)
+    .filter(path => path.toLowerCase().endsWith('.model3.json'))
+  customChar.modelPath = modelFiles.length === 1 ? modelFiles[0] ?? '' : ''
 }
 
-function applyCustomCharacter() {
+async function applyCustomCharacter() {
+  if (!customReady.value || customChar.uploading)
+    return
+  customChar.uploading = true
+  try {
+    const res = await API.uploadCustomLive2DModel({
+      name: customChar.name.trim(),
+      files: customChar.modelFiles,
+      modelPath: customChar.modelPath || undefined,
+    })
+    const savedModel = upsertCustomLive2DModel(res.model)
+    applyCustomLive2DModel(savedModel)
+    toast.add({ severity: 'success', summary: '角色已录入', detail: customChar.name.trim(), life: 2500 })
+  }
+  catch (e: any) {
+    toast.add({ severity: 'error', summary: '录入失败', detail: e?.response?.data?.detail || e.message, life: 4000 })
+    return
+  }
+  finally {
+    customChar.uploading = false
+  }
   CONFIG.value.system.ai_name = customChar.name
   CONFIG.value.system.active_character = ''
+  SYSTEM_PROMPT.value = customChar.prompt
 }
 
 // 标签可见时执行初始化
@@ -530,13 +562,18 @@ async function handleRedeem() {
                 <input
                   ref="fileInputRef"
                   type="file"
-                  accept=".model3.json"
+                  webkitdirectory
+                  directory
+                  multiple
                   style="display:none"
                   @change="onFileChange"
                 >
                 <button type="button" class="custom-file-btn" @click="triggerFileInput">
-                  {{ customChar.modelFile ? customChar.modelFile.name : '选择 .model3.json 文件' }}
+                  {{ customChar.modelFiles.length ? `${customChar.modelFiles.length} 个模型资源文件` : '选择 Live2D 模型目录' }}
                 </button>
+                <span v-if="customChar.modelPath" class="custom-file-hint">
+                  {{ customChar.modelPath }}
+                </span>
               </div>
               <label class="custom-field custom-field-grow">
                 <span class="custom-field-label">系统提示词</span>
@@ -550,10 +587,10 @@ async function handleRedeem() {
                 type="button"
                 class="char-apply-btn"
                 :class="{ disabled: !customReady }"
-                :disabled="!customReady"
+                :disabled="!customReady || customChar.uploading"
                 @click.stop="customReady && applyCustomCharacter()"
               >
-                录入角色
+                {{ customChar.uploading ? '录入中...' : '录入角色' }}
               </button>
             </div>
           </div>
@@ -1348,6 +1385,13 @@ async function handleRedeem() {
 .custom-file-btn:hover {
   border-color: rgba(251, 191, 36, 0.45);
   background: rgba(255, 255, 255, 0.08);
+}
+
+.custom-file-hint {
+  color: rgba(248, 250, 252, 0.44);
+  font-size: 10px;
+  line-height: 1.4;
+  overflow-wrap: anywhere;
 }
 
 .custom-textarea {

--- a/system/live2d_assets.py
+++ b/system/live2d_assets.py
@@ -1,0 +1,256 @@
+"""自定义 Live2D 模型资源管理。"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path, PurePosixPath
+from typing import Any, Protocol
+from urllib.parse import quote
+from uuid import uuid4
+
+from .config import get_data_dir
+
+
+class UploadedLive2DFile(Protocol):
+    """FastAPI UploadFile 的最小协议，便于单元测试复用。"""
+
+    filename: str | None
+
+    async def read(self, size: int = -1) -> bytes:
+        ...
+
+    async def close(self) -> None:
+        ...
+
+
+CUSTOM_LIVE2D_DIR = get_data_dir() / "live2d" / "custom_models"
+CUSTOM_LIVE2D_INDEX = CUSTOM_LIVE2D_DIR / "models.json"
+MAX_LIVE2D_FILE_COUNT = 512
+MAX_LIVE2D_TOTAL_BYTES = 300 * 1024 * 1024
+_MODEL_ID_RE = re.compile(r"^[a-f0-9]{32}$")
+_ALLOWED_ASSET_SUFFIXES = {
+    ".json",
+    ".moc3",
+    ".png",
+    ".jpg",
+    ".jpeg",
+    ".webp",
+    ".gif",
+    ".mp3",
+    ".wav",
+    ".ogg",
+    ".m4a",
+    ".webm",
+    ".txt",
+    ".bytes",
+    ".atlas",
+}
+
+
+def sanitize_live2d_model_name(name: str) -> str:
+    """清理展示名称，保留中英文等可见字符。"""
+    normalized = " ".join(str(name or "").strip().split())
+    if not normalized:
+        raise ValueError("模型名称不能为空")
+    if len(normalized) > 80:
+        raise ValueError("模型名称不能超过 80 个字符")
+    return normalized
+
+
+def normalize_live2d_upload_path(filename: str | None) -> PurePosixPath:
+    """将上传文件名规范化为安全的 POSIX 相对路径。"""
+    raw = str(filename or "").replace("\\", "/").strip()
+    raw = raw.lstrip("/")
+    path = PurePosixPath(raw)
+    if not raw or path.is_absolute():
+        raise ValueError("上传文件路径无效")
+    if any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"上传文件路径不安全: {filename}")
+    if len(path.parts) > 24:
+        raise ValueError(f"上传文件路径过深: {filename}")
+    return path
+
+
+def is_allowed_live2d_asset_path(path: PurePosixPath) -> bool:
+    """判断资源扩展名是否适合公开为 Live2D 静态资源。"""
+    return Path(path.name).suffix.lower() in _ALLOWED_ASSET_SUFFIXES
+
+
+def find_live2d_model_path(paths: list[PurePosixPath], requested_model_path: str | None = None) -> PurePosixPath:
+    """从上传文件中定位 .model3.json 文件。"""
+    if requested_model_path:
+        requested = normalize_live2d_upload_path(requested_model_path)
+        if requested not in paths:
+            raise ValueError("指定的模型文件不在上传内容中")
+        if not requested.name.lower().endswith(".model3.json"):
+            raise ValueError("模型文件必须是 .model3.json")
+        return requested
+
+    model_paths = [path for path in paths if path.name.lower().endswith(".model3.json")]
+    if not model_paths:
+        raise ValueError("上传目录中没有找到 .model3.json 模型文件")
+    if len(model_paths) > 1:
+        raise ValueError("上传目录中包含多个 .model3.json，请选择具体模型文件")
+    return model_paths[0]
+
+
+def _ensure_storage() -> None:
+    CUSTOM_LIVE2D_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _read_index() -> dict[str, Any]:
+    _ensure_storage()
+    if not CUSTOM_LIVE2D_INDEX.exists():
+        return {"version": 1, "models": []}
+    try:
+        data = json.loads(CUSTOM_LIVE2D_INDEX.read_text(encoding="utf-8"))
+    except Exception:
+        return {"version": 1, "models": []}
+    if not isinstance(data, dict):
+        return {"version": 1, "models": []}
+    models = data.get("models")
+    if not isinstance(models, list):
+        data["models"] = []
+    data.setdefault("version", 1)
+    return data
+
+
+def _write_index(data: dict[str, Any]) -> None:
+    _ensure_storage()
+    fd, tmp_path = tempfile.mkstemp(dir=str(CUSTOM_LIVE2D_DIR), prefix=".models_", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(data, handle, ensure_ascii=False, indent=2)
+        Path(tmp_path).replace(CUSTOM_LIVE2D_INDEX)
+    except BaseException:
+        try:
+            Path(tmp_path).unlink(missing_ok=True)
+        finally:
+            raise
+
+
+def _validate_model_id(model_id: str) -> str:
+    normalized = str(model_id or "").strip()
+    if not _MODEL_ID_RE.fullmatch(normalized):
+        raise ValueError("模型 ID 无效")
+    return normalized
+
+
+def _public_model_payload(model: dict[str, Any], api_port: int) -> dict[str, Any]:
+    model_id = str(model.get("id") or "")
+    model_path = str(model.get("model_path") or "")
+    encoded_model_path = quote(model_path, safe="/")
+    return {
+        **model,
+        "source": f"http://localhost:{api_port}/custom-live2d/{quote(model_id, safe='')}/{encoded_model_path}",
+    }
+
+
+def list_custom_live2d_models(api_port: int) -> list[dict[str, Any]]:
+    """列出可供前端使用的自定义 Live2D 模型。"""
+    data = _read_index()
+    models = [item for item in data.get("models", []) if isinstance(item, dict)]
+    return [_public_model_payload(model, api_port) for model in models]
+
+
+def get_custom_live2d_model(model_id: str, api_port: int) -> dict[str, Any] | None:
+    """读取单个自定义 Live2D 模型。"""
+    normalized_id = _validate_model_id(model_id)
+    data = _read_index()
+    for model in data.get("models", []):
+        if isinstance(model, dict) and model.get("id") == normalized_id:
+            return _public_model_payload(model, api_port)
+    return None
+
+
+async def create_custom_live2d_model(
+    name: str,
+    files: list[UploadedLive2DFile],
+    requested_model_path: str | None,
+    api_port: int,
+) -> dict[str, Any]:
+    """保存一组 Live2D 资源文件并返回模型元数据。"""
+    display_name = sanitize_live2d_model_name(name)
+    if not files:
+        raise ValueError("请上传 Live2D 模型目录")
+    if len(files) > MAX_LIVE2D_FILE_COUNT:
+        raise ValueError(f"上传文件数量不能超过 {MAX_LIVE2D_FILE_COUNT}")
+
+    _ensure_storage()
+    model_id = uuid4().hex
+    temp_dir = CUSTOM_LIVE2D_DIR / f".{model_id}.tmp"
+    final_dir = CUSTOM_LIVE2D_DIR / model_id
+    paths: list[PurePosixPath] = []
+    seen_paths: set[str] = set()
+    total_bytes = 0
+
+    try:
+        temp_dir.mkdir(parents=True, exist_ok=False)
+        for upload in files:
+            rel_path = normalize_live2d_upload_path(upload.filename)
+            rel_key = rel_path.as_posix()
+            if rel_key in seen_paths:
+                raise ValueError(f"上传目录包含重复文件: {rel_key}")
+            if not is_allowed_live2d_asset_path(rel_path):
+                raise ValueError(f"不支持的 Live2D 资源类型: {rel_key}")
+
+            seen_paths.add(rel_key)
+            paths.append(rel_path)
+            target_path = temp_dir / rel_key
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            with target_path.open("wb") as handle:
+                while True:
+                    chunk = await upload.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    total_bytes += len(chunk)
+                    if total_bytes > MAX_LIVE2D_TOTAL_BYTES:
+                        raise ValueError("Live2D 模型资源总大小超过限制")
+                    handle.write(chunk)
+            await upload.close()
+
+        model_path = find_live2d_model_path(paths, requested_model_path).as_posix()
+        final_dir.parent.mkdir(parents=True, exist_ok=True)
+        temp_dir.replace(final_dir)
+
+        metadata = {
+            "id": model_id,
+            "name": display_name,
+            "model_path": model_path,
+            "file_count": len(paths),
+            "total_bytes": total_bytes,
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+        index = _read_index()
+        index["models"] = [
+            item for item in index.get("models", [])
+            if not isinstance(item, dict) or item.get("id") != model_id
+        ]
+        index["models"].append(metadata)
+        _write_index(index)
+        return _public_model_payload(metadata, api_port)
+    except BaseException:
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        shutil.rmtree(final_dir, ignore_errors=True)
+        raise
+
+
+def delete_custom_live2d_model(model_id: str) -> bool:
+    """删除自定义 Live2D 模型。"""
+    normalized_id = _validate_model_id(model_id)
+    index = _read_index()
+    before = len(index.get("models", []))
+    index["models"] = [
+        item for item in index.get("models", [])
+        if not isinstance(item, dict) or item.get("id") != normalized_id
+    ]
+    deleted = len(index["models"]) != before
+    shutil.rmtree(CUSTOM_LIVE2D_DIR / normalized_id, ignore_errors=True)
+    if deleted:
+        _write_index(index)
+    return deleted

--- a/tests/test_live2d_assets.py
+++ b/tests/test_live2d_assets.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import asyncio
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch
+
+from system import live2d_assets
+
+
+class MemoryUpload:
+    def __init__(self, filename: str, content: bytes) -> None:
+        self.filename = filename
+        self._content = content
+        self._offset = 0
+        self.closed = False
+
+    async def read(self, size: int = -1) -> bytes:
+        if size < 0:
+            size = len(self._content) - self._offset
+        chunk = self._content[self._offset:self._offset + size]
+        self._offset += len(chunk)
+        return chunk
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class Live2DAssetsTest(unittest.TestCase):
+    def test_normalize_live2d_upload_path_rejects_traversal(self) -> None:
+        with self.assertRaises(ValueError):
+            live2d_assets.normalize_live2d_upload_path("../evil.model3.json")
+
+        with self.assertRaises(ValueError):
+            live2d_assets.normalize_live2d_upload_path("model/../../evil.model3.json")
+
+    def test_find_live2d_model_path_requires_single_model_file(self) -> None:
+        paths = [
+            live2d_assets.normalize_live2d_upload_path("avatar/avatar.model3.json"),
+            live2d_assets.normalize_live2d_upload_path("avatar/texture_00.png"),
+        ]
+
+        self.assertEqual(
+            live2d_assets.find_live2d_model_path(paths).as_posix(),
+            "avatar/avatar.model3.json",
+        )
+
+        with self.assertRaises(ValueError):
+            live2d_assets.find_live2d_model_path(paths, "avatar/texture_00.png")
+
+    def test_create_and_delete_custom_live2d_model(self) -> None:
+        with TemporaryDirectory() as tmp:
+            storage_dir = Path(tmp) / "custom_models"
+            with (
+                patch.object(live2d_assets, "CUSTOM_LIVE2D_DIR", storage_dir),
+                patch.object(live2d_assets, "CUSTOM_LIVE2D_INDEX", storage_dir / "models.json"),
+            ):
+                files = [
+                    MemoryUpload("avatar/avatar.model3.json", b'{"Version":3}'),
+                    MemoryUpload("avatar/avatar.moc3", b"moc"),
+                    MemoryUpload("avatar/textures/texture_00.png", b"png"),
+                ]
+
+                model = asyncio.run(
+                    live2d_assets.create_custom_live2d_model(
+                        name=" 测试模型 ",
+                        files=files,
+                        requested_model_path=None,
+                        api_port=8000,
+                    )
+                )
+
+                self.assertEqual(model["name"], "测试模型")
+                self.assertEqual(model["model_path"], "avatar/avatar.model3.json")
+                self.assertEqual(model["file_count"], 3)
+                self.assertTrue(model["source"].endswith(f"/custom-live2d/{model['id']}/avatar/avatar.model3.json"))
+                self.assertTrue((storage_dir / model["id"] / "avatar" / "avatar.model3.json").exists())
+
+                loaded = live2d_assets.get_custom_live2d_model(model["id"], 9000)
+                self.assertIsNotNone(loaded)
+                self.assertTrue(loaded["source"].startswith("http://localhost:9000/"))
+
+                self.assertTrue(live2d_assets.delete_custom_live2d_model(model["id"]))
+                self.assertFalse((storage_dir / model["id"]).exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add backend APIs and static hosting for user-uploaded Live2D model directories
- add frontend upload/apply/delete controls in terminal settings and market character registration
- document custom Live2D configuration and add backend asset tests

## Verification
- uv run python -m unittest tests.test_live2d_assets
- uv run ruff check system/live2d_assets.py tests/test_live2d_assets.py apiserver/routes/system.py
- node node_modules/eslint/bin/eslint.js src/App.vue src/api/core.ts src/utils/config.ts src/utils/live2dModels.ts src/views/ConfigView.vue src/views/MarketView.vue
- npm run build