### PR TITLE
Fix skill path traversal and floating drag growth

### DIFF
--- a/apiserver/README.md
+++ b/apiserver/README.md
@@ -146,6 +146,8 @@ OpenClaw 配置桥接会在生成、迁移或注入配置时补齐 `gateway.mode
 | POST | `/travel/sessions/{session_id}/browser` | 更新探索浏览器策略 |
 | GET  | `/memory/stats` | 记忆系统统计 |
 | GET  | `/memory/quintuples` | 获取五元组 |
+
+技能管理接口会将 `name` 当作技能目录标识处理，只允许单段名称；空名称、`.`、`..`、包含 `/` 或 `\`、绝对路径、Windows 盘符路径和控制字符会被拒绝，避免写入、读取或删除越过技能目录边界。
 | GET  | `/memory/quintuples/search` | 搜索五元组 |
 | GET/POST | `/tools/search` | 搜索代理 |
 

--- a/apiserver/routes/extensions.py
+++ b/apiserver/routes/extensions.py
@@ -11,7 +11,7 @@ import sys
 import time
 import traceback
 from datetime import datetime
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Dict, List, Optional, Any, Tuple
 from urllib.request import Request as UrlRequest, urlopen
 from urllib.error import URLError
@@ -49,6 +49,7 @@ MCPORTER_CONFIG_PATH = MCPORTER_DIR / "config.json"
 LEGACY_MCPORTER_DIR = Path.home() / ".mcporter"
 LEGACY_MCPORTER_CONFIG_PATH = LEGACY_MCPORTER_DIR / "config.json"
 SKILL_FRONTMATTER_PATTERN = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+MAX_SKILL_NAME_LENGTH = 120
 
 for _path in (OPENCLAW_SKILLS_DIR, NAGA_PUBLIC_SKILLS_DIR, NAGA_CACHE_SKILLS_DIR, NAGA_AGENTS_DIR):
     _path.mkdir(parents=True, exist_ok=True)
@@ -150,8 +151,50 @@ def _write_skill_file(skill_name: str, content: str) -> Path:
     return _write_skill_file_to_dir(OPENCLAW_SKILLS_DIR, skill_name, content)
 
 
+def _normalize_skill_name(skill_name: str) -> str:
+    name = (skill_name or "").strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="技能名称不能为空")
+    if len(name) > MAX_SKILL_NAME_LENGTH:
+        raise HTTPException(status_code=400, detail=f"技能名称不能超过 {MAX_SKILL_NAME_LENGTH} 个字符")
+    if name in {".", ".."}:
+        raise HTTPException(status_code=400, detail="技能名称不能是路径保留名称")
+    if "/" in name or "\\" in name:
+        raise HTTPException(status_code=400, detail="技能名称不能包含路径分隔符")
+    if any(ord(ch) < 32 or ord(ch) == 127 for ch in name):
+        raise HTTPException(status_code=400, detail="技能名称不能包含控制字符")
+
+    posix_path = PurePosixPath(name)
+    windows_path = PureWindowsPath(name)
+    if posix_path.is_absolute() or windows_path.is_absolute() or windows_path.drive or windows_path.root:
+        raise HTTPException(status_code=400, detail="技能名称不能是绝对路径或盘符路径")
+    return name
+
+
+def _resolve_child_dir(base_dir: Path, child_name: str, label: str = "技能名称") -> Path:
+    name = _normalize_skill_name(child_name)
+    base = base_dir.resolve(strict=False)
+    target = (base / name).resolve(strict=False)
+    try:
+        target.relative_to(base)
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"{label} 指向了不允许的目录")
+    if target == base:
+        raise HTTPException(status_code=400, detail=f"{label} 不能指向根目录")
+    return target
+
+
+def _resolve_skill_dir(base_dir: Path, skill_name: str) -> Path:
+    return _resolve_child_dir(base_dir, skill_name, "技能名称")
+
+
+def _resolve_agent_skills_dir(agent_id: str) -> Path:
+    agent_dir = _resolve_child_dir(NAGA_AGENTS_DIR, agent_id, "agent_id")
+    return agent_dir / "skills"
+
+
 def _write_skill_file_to_dir(base_dir: Path, skill_name: str, content: str) -> Path:
-    skill_dir = base_dir / skill_name
+    skill_dir = _resolve_skill_dir(base_dir, skill_name)
     skill_dir.mkdir(parents=True, exist_ok=True)
     skill_path = skill_dir / "SKILL.md"
     skill_path.write_text(content, encoding="utf-8")
@@ -1315,6 +1358,7 @@ enabled: true
 
 
 def _write_skill_to_scope(name: str, content: str, scope: str, agent_id: Optional[str] = None) -> Path:
+    name = _normalize_skill_name(name)
     rendered_content = _render_skill_file_content(name, content)
 
     if scope == "openclaw-local":
@@ -1337,22 +1381,23 @@ def _write_skill_to_scope(name: str, content: str, scope: str, agent_id: Optiona
         agent = _get_agent_record(agent_id)
         if not agent:
             raise HTTPException(status_code=404, detail="目标干员不存在")
-        agent_skill_dir = NAGA_AGENTS_DIR / agent_id / "skills"
+        agent_skill_dir = _resolve_agent_skills_dir(agent_id)
         return _write_skill_file_to_dir(agent_skill_dir, name, rendered_content)
 
     raise HTTPException(status_code=400, detail=f"未知技能范围: {scope}")
 
 
 def _delete_skill_from_scope(name: str, scope: str, agent_id: Optional[str] = None) -> Path:
+    name = _normalize_skill_name(name)
     if scope == "cache":
-        candidates = [NAGA_CACHE_SKILLS_DIR / name, OPENCLAW_SKILLS_DIR / name]
+        candidates = [_resolve_skill_dir(NAGA_CACHE_SKILLS_DIR, name), _resolve_skill_dir(OPENCLAW_SKILLS_DIR, name)]
     elif scope == "public":
-        candidates = [NAGA_PUBLIC_SKILLS_DIR / name]
+        candidates = [_resolve_skill_dir(NAGA_PUBLIC_SKILLS_DIR, name)]
     elif scope == "private":
         agent_id = (agent_id or "").strip()
         if not agent_id:
             raise HTTPException(status_code=400, detail="私有技能必须指定 agent_id")
-        candidates = [NAGA_AGENTS_DIR / agent_id / "skills" / name]
+        candidates = [_resolve_skill_dir(_resolve_agent_skills_dir(agent_id), name)]
     else:
         raise HTTPException(status_code=400, detail=f"未知技能范围: {scope}")
 
@@ -1371,19 +1416,20 @@ def _delete_skill_from_scope(name: str, scope: str, agent_id: Optional[str] = No
 
 
 def _read_skill_content_from_scope(name: str, scope: str, agent_id: Optional[str] = None) -> str:
+    name = _normalize_skill_name(name)
     candidates: List[Path]
     if scope == "cache":
         candidates = [
-            NAGA_CACHE_SKILLS_DIR / name / "SKILL.md",
-            OPENCLAW_SKILLS_DIR / name / "SKILL.md",
+            _resolve_skill_dir(NAGA_CACHE_SKILLS_DIR, name) / "SKILL.md",
+            _resolve_skill_dir(OPENCLAW_SKILLS_DIR, name) / "SKILL.md",
         ]
     elif scope == "public":
-        candidates = [NAGA_PUBLIC_SKILLS_DIR / name / "SKILL.md"]
+        candidates = [_resolve_skill_dir(NAGA_PUBLIC_SKILLS_DIR, name) / "SKILL.md"]
     elif scope == "private":
         agent_id = (agent_id or "").strip()
         if not agent_id:
             raise HTTPException(status_code=400, detail="私有技能必须指定 source_agent_id")
-        candidates = [NAGA_AGENTS_DIR / agent_id / "skills" / name / "SKILL.md"]
+        candidates = [_resolve_skill_dir(_resolve_agent_skills_dir(agent_id), name) / "SKILL.md"]
     else:
         raise HTTPException(status_code=400, detail=f"未知技能范围: {scope}")
 
@@ -1500,7 +1546,10 @@ def _build_skill_catalog() -> Dict[str, Any]:
         agent_id = agent.get("id")
         if not agent_id:
             continue
-        agent_dir = NAGA_AGENTS_DIR / str(agent_id) / "skills"
+        try:
+            agent_dir = _resolve_agent_skills_dir(str(agent_id))
+        except HTTPException:
+            continue
         private_skills.extend(
             _list_skill_dir(
                 agent_dir,
@@ -1613,6 +1662,9 @@ async def clone_skill(request: SkillCloneRequest):
 
 @router.delete("/skills/{name}")
 async def delete_skill(name: str, scope: str, agent_id: Optional[str] = None):
+    scope = (scope or "").strip().lower()
+    if scope == "legacy":
+        scope = "cache"
     telemetry_props = {
         "name": name,
         "scope": scope,

--- a/frontend/electron/modules/window.ts
+++ b/frontend/electron/modules/window.ts
@@ -362,6 +362,9 @@ export function setWindowPosition(x: number, y: number): void {
     return
   const rx = Math.round(x)
   const ry = Math.round(y)
+  if (floatingState !== 'classic') {
+    cancelCurrentAnimation?.()
+  }
   win.setPosition(rx, ry)
   // 任何悬浮球相关状态拖拽时都同步位置（球态/展开态都需要）
   if (floatingState !== 'classic') {

--- a/frontend/src/views/FloatingView.vue
+++ b/frontend/src/views/FloatingView.vue
@@ -132,6 +132,7 @@ let unsubBlur: (() => void) | undefined
 let resizeObserver: ResizeObserver | null = null
 let fitRAF = 0
 let _lastFitHeight = 0 // 防止 ResizeObserver 反馈循环
+const isDraggingWindow = ref(false)
 
 // ─── 会话历史（声明前置，fitWindowHeight 需要引用） ──────
 const showHistory = ref(false)
@@ -139,6 +140,8 @@ const showHistory = ref(false)
 // 根据消息内容自适应窗口高度
 function fitWindowHeight() {
   if (floatingState.value !== 'full')
+    return
+  if (isDraggingWindow.value)
     return
   const el = messageContentRef.value
   if (!el)
@@ -261,6 +264,7 @@ let dragState: { screenX: number, screenY: number, winX: number, winY: number } 
 let hasDragged = false
 
 function onDragPointerDown(e: PointerEvent) {
+  isDraggingWindow.value = true
   dragState = {
     screenX: e.screenX,
     screenY: e.screenY,
@@ -284,22 +288,32 @@ function onDragPointerMove(e: PointerEvent) {
 
 function onDragPointerUp(e: PointerEvent) {
   if (!dragState) {
+    isDraggingWindow.value = false
     return
   }
   ;(e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId)
+  const moved = hasDragged
   dragState = null
+  isDraggingWindow.value = false
+  if (moved)
+    requestFitHeight()
 }
 
 // 球态：拖拽 + 点击展开（pointerup 需要区分拖拽和点击）
 function onBallPointerUp(e: PointerEvent) {
   if (!dragState) {
+    isDraggingWindow.value = false
     return
   }
   ;(e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId)
-  if (!hasDragged) {
+  const moved = hasDragged
+  if (!moved) {
     handleBallClick()
   }
   dragState = null
+  isDraggingWindow.value = false
+  if (moved)
+    requestFitHeight()
 }
 
 // 紧凑态/完整态球：拖拽 + 点击收起
@@ -310,13 +324,18 @@ function onCompactBallPointerDown(e: PointerEvent) {
 
 function onCompactBallPointerUp(e: PointerEvent) {
   if (!dragState) {
+    isDraggingWindow.value = false
     return
   }
   ;(e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId)
-  if (!hasDragged) {
+  const moved = hasDragged
+  if (!moved) {
     handleCollapse()
   }
   dragState = null
+  isDraggingWindow.value = false
+  if (moved)
+    requestFitHeight()
 }
 
 function handleCollapse() {

--- a/skills/naga-config/SKILL.md
+++ b/skills/naga-config/SKILL.md
@@ -138,6 +138,8 @@ Content-Type: application/json
 
 技能文件会被创建为 `skills/{name}/SKILL.md`，包含 YAML frontmatter 元数据和 Markdown 内容。技能会在下次对话时自动加载到系统提示词中。
 
+`name` 是单段技能目录标识，不能是空值、`.`、`..`，也不能包含 `/`、`\`、绝对路径、Windows 盘符路径或控制字符。
+
 ### 自定义技能内容建议格式
 ```markdown
 # 技能标题

--- a/tests/test_config_and_tools.py
+++ b/tests/test_config_and_tools.py
@@ -8,10 +8,12 @@ from typing import Any
 from unittest.mock import patch
 
 import httpx
+from fastapi import HTTPException
 
 from apiserver import naga_auth
 from apiserver.api_server import app as api_app
 from apiserver.agentic_tool_loop import _execute_local_tool, format_tool_result_for_display
+from apiserver.routes import extensions as extensions_routes
 from apiserver.routes import openai_proxy
 from apiserver.routes import tools as tools_routes
 from apiserver.routes.system import _sanitize_system_config_payload
@@ -729,6 +731,59 @@ class ConfigAndToolTests(unittest.TestCase):
                     )
 
         asyncio.run(_run_request())
+
+    def test_skill_write_rejects_path_traversal_names(self) -> None:
+        traversal_names = [
+            "../escape",
+            "..\\escape",
+            "..",
+            "/tmp/escape",
+            "C:\\Temp\\escape",
+            "\\\\server\\share\\escape",
+            "nested/skill",
+            "nested\\skill",
+        ]
+
+        with TemporaryDirectory() as tmp_dir:
+            base_dir = Path(tmp_dir) / "skills"
+            for name in traversal_names:
+                with self.subTest(name=name):
+                    with self.assertRaises(HTTPException):
+                        extensions_routes._write_skill_file_to_dir(base_dir, name, "poc")
+
+            skill_path = extensions_routes._write_skill_file_to_dir(base_dir, "safe-skill_1", "ok")
+            self.assertEqual(skill_path, base_dir.resolve() / "safe-skill_1" / "SKILL.md")
+            self.assertEqual(skill_path.read_text(encoding="utf-8"), "ok")
+
+    def test_skill_delete_and_read_reject_path_traversal_names(self) -> None:
+        with TemporaryDirectory() as tmp_dir:
+            data_dir = Path(tmp_dir)
+            public_dir = data_dir / "skills" / "public"
+            public_dir.mkdir(parents=True)
+            (public_dir / "safe").mkdir()
+            (public_dir / "safe" / "SKILL.md").write_text("content", encoding="utf-8")
+
+            outside_dir = data_dir / "outside"
+            outside_dir.mkdir()
+            marker = outside_dir / "keep.txt"
+            marker.write_text("keep", encoding="utf-8")
+
+            with (
+                patch.object(extensions_routes, "NAGA_PUBLIC_SKILLS_DIR", public_dir),
+                patch.object(extensions_routes, "NAGA_CACHE_SKILLS_DIR", data_dir / "skills" / "cache"),
+                patch.object(extensions_routes, "OPENCLAW_SKILLS_DIR", data_dir / "openclaw" / "skills"),
+                patch.object(extensions_routes, "NAGA_AGENTS_DIR", data_dir / "agents"),
+            ):
+                with self.assertRaises(HTTPException):
+                    extensions_routes._delete_skill_from_scope("../outside", "public")
+                with self.assertRaises(HTTPException):
+                    extensions_routes._read_skill_content_from_scope("../outside", "public")
+
+                self.assertTrue(marker.exists())
+                self.assertEqual(extensions_routes._read_skill_content_from_scope("safe", "public"), "content")
+                deleted_path = extensions_routes._delete_skill_from_scope("safe", "public")
+                self.assertEqual(deleted_path, public_dir.resolve() / "safe")
+                self.assertFalse(deleted_path.exists())
 
     def test_openai_proxy_uses_local_api_when_gateway_disabled(self) -> None:
         class _ProxyApiSettings:


### PR DESCRIPTION
## Summary
- harden skill import/clone/read/delete paths by validating skill names and enforcing resolved directory containment
- add regression tests for traversal payloads against skill write/read/delete flows
- stabilize expanded floating-window dragging by pausing fitHeight during drag and cancelling competing bounds animations
- document skill name restrictions in API and naga-config docs

## Related issues
- Fixes RTGS2017/NagaAgent#311
- Refs RTGS2017/NagaAgent#273

## Tests
- uv run ruff check apiserver/routes/extensions.py tests/test_config_and_tools.py
- env UV_CACHE_DIR=/tmp/uv-cache uv run --with pytest pytest tests/test_config_and_tools.py
- npm run lint
- npm run build